### PR TITLE
🎨 Palette: Add ARIA labels to icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-12 - Added ARIA labels to Icon Buttons
+**Learning:** Found multiple instances where icon-only buttons lacked accessible labels in `habit_tracker_component.tsx` and `job_tracker_component.tsx`. This makes UI interactions difficult for screen readers.
+**Action:** Always verify that interactive elements without text content have `aria-label`s or visually-hidden text. Adding `aria-label` improves a11y without affecting the visual design.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -93,7 +93,7 @@ const Modal = ({ title, onClose, dark, children }) => {
       <div className={cn("w-full max-w-md rounded-xl border shadow-2xl", modal)}>
         <div className="flex items-center justify-between px-5 py-4 border-b" style={{ borderColor: divCol }}>
           <h2 className={cn("font-semibold text-base", titleCls)}>{title}</h2>
-          <button onClick={onClose} className={cn("p-1.5 rounded-md transition-colors", closeCls)}>
+          <button onClick={onClose} className={cn("p-1.5 rounded-md transition-colors", closeCls)} aria-label="Close modal">
             <X className="w-4 h-4" />
           </button>
         </div>
@@ -318,13 +318,13 @@ export const Component = () => {
                   {filterConfig && (
                     <div className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium", t.pill)}>
                       <Filter className="w-3 h-3" />Filtered
-                      <button onClick={() => setFilterConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
+                      <button onClick={() => setFilterConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100" aria-label="Clear filter"><X className="w-3 h-3" /></button>
                     </div>
                   )}
                   {sortConfig && (
                     <div className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium", t.pill)}>
                       <ArrowUpDown className="w-3 h-3" />Sorted
-                      <button onClick={() => setSortConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
+                      <button onClick={() => setSortConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100" aria-label="Clear sort"><X className="w-3 h-3" /></button>
                     </div>
                   )}
                 </div>
@@ -374,7 +374,8 @@ export const Component = () => {
 
                 {/* Zap: toggle all */}
                 <button onClick={handleToggleAll} title="Toggle all habits"
-                  className={cn("p-2 rounded-md transition-colors", t.iconBtn, t.subtext)}>
+                  className={cn("p-2 rounded-md transition-colors", t.iconBtn, t.subtext)}
+                  aria-label="Toggle all habits">
                   <Zap className="w-4 h-4" />
                 </button>
 

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -341,6 +341,7 @@ export const Component = () => {
                   <button
                     onClick={(e) => { e.preventDefault(); setResumeFile(null); }}
                     style={{ background: "none", border: "none", cursor: "pointer", color: t.muted, padding: 2 }}
+                    aria-label="Remove resume"
                   >
                     <XIcon size={12} />
                   </button>
@@ -406,6 +407,7 @@ export const Component = () => {
               <div style={{ position: "relative" }} ref={filterMenuRef}>
                 <button
                   title="Filter by stage"
+                  aria-label="Filter by stage"
                   onClick={() => setShowFilterMenu((v) => !v)}
                   style={iconBtn(filterStage !== "all" || showFilterMenu)}
                 >
@@ -450,6 +452,7 @@ export const Component = () => {
               <div style={{ position: "relative" }} ref={sortMenuRef}>
                 <button
                   title="Sort"
+                  aria-label="Sort apps"
                   onClick={() => setShowSortMenu((v) => !v)}
                   style={iconBtn(sortField !== "none" || showSortMenu)}
                 >
@@ -507,6 +510,7 @@ export const Component = () => {
               {/* Search */}
               <button
                 title="Search"
+                aria-label="Search apps"
                 onClick={() => { setShowSearch((v) => !v); setTimeout(() => searchRef.current?.focus(), 50); }}
                 style={iconBtn(showSearch)}
               >
@@ -518,6 +522,7 @@ export const Component = () => {
               {/* Expand */}
               <button
                 title={isExpanded ? "Collapse" : "Expand"}
+                aria-label={isExpanded ? "Collapse" : "Expand"}
                 onClick={() => setIsExpanded((v) => !v)}
                 style={iconBtn(isExpanded)}
               >
@@ -532,6 +537,7 @@ export const Component = () => {
               {/* Settings */}
               <button
                 title="Settings"
+                aria-label="Settings"
                 onClick={() => setShowSettings(true)}
                 style={iconBtn(showSettings)}
               >
@@ -562,6 +568,7 @@ export const Component = () => {
                       borderRadius: "0 8px 8px 0", padding: "7px 8px",
                       cursor: "pointer",
                     }}
+                    aria-label="Select stage for new application"
                   >
                     <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
                       <polyline points="6 9 12 15 18 9" />
@@ -621,6 +628,7 @@ export const Component = () => {
                 <button
                   onClick={() => setSearchQuery("")}
                   style={{ position: "absolute", right: 8, top: "50%", transform: "translateY(-50%)", background: "none", border: "none", cursor: "pointer", color: t.muted }}
+                  aria-label="Clear search"
                 >
                   <XIcon size={13} />
                 </button>
@@ -638,7 +646,7 @@ export const Component = () => {
                   display: "flex", alignItems: "center", gap: 6,
                 }}>
                   Stage: {STAGES.find((s) => s.key === filterStage)?.label}
-                  <button onClick={() => setFilterStage("all")} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
+                  <button onClick={() => setFilterStage("all")} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }} aria-label="Clear filter">×</button>
                 </span>
               )}
               {sortField !== "none" && (
@@ -648,7 +656,7 @@ export const Component = () => {
                   display: "flex", alignItems: "center", gap: 6,
                 }}>
                   Sort: {sortField} {sortDir === "asc" ? "↑" : "↓"}
-                  <button onClick={clearSort} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
+                  <button onClick={clearSort} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }} aria-label="Clear sort">×</button>
                 </span>
               )}
             </div>
@@ -748,6 +756,7 @@ export const Component = () => {
                       style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, color: t.subtle, background: "transparent", border: "none", cursor: "pointer", fontFamily: "inherit", padding: "8px 4px", borderRadius: 6, width: "100%" }}
                       onMouseEnter={(e) => (e.currentTarget.style.color = t.muted)}
                       onMouseLeave={(e) => (e.currentTarget.style.color = t.subtle)}
+                      aria-label="Add new application to this stage"
                     >
                       <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg>
                       New page
@@ -828,6 +837,7 @@ export const Component = () => {
                         onClick={() => setEditApp({ ...app })}
                         style={{ background: t.surfaceAlt, border: "none", borderRadius: 5, width: 28, height: 28, cursor: "pointer", color: t.muted, display: "flex", alignItems: "center", justifyContent: "center" }}
                         title="Edit"
+                        aria-label="Edit application"
                       >
                         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg>
                       </button>
@@ -835,6 +845,7 @@ export const Component = () => {
                         onClick={() => deleteApp(app.id)}
                         style={{ background: t.surfaceAlt, border: "none", borderRadius: 5, width: 28, height: 28, cursor: "pointer", color: "#ef4444", display: "flex", alignItems: "center", justifyContent: "center" }}
                         title="Delete"
+                        aria-label="Delete application"
                       >
                         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="3 6 5 6 21 6" /><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" /><path d="M10 11v6M14 11v6" /><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" /></svg>
                       </button>
@@ -885,6 +896,7 @@ export const Component = () => {
                   onMouseEnter={(e) => (e.currentTarget.style.color = "#ef4444")}
                   onMouseLeave={(e) => (e.currentTarget.style.color = t.subtle)}
                   title="Delete"
+                  aria-label="Delete action item"
                 >
                   <XIcon size={13} />
                 </button>
@@ -933,7 +945,7 @@ export const Component = () => {
                   <div style={{ fontSize: 13, color: t.muted }}>{selectedApp.role}</div>
                 </div>
               </div>
-              <button onClick={() => setSelectedApp(null)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}>
+              <button onClick={() => setSelectedApp(null)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }} aria-label="Close modal">
                 <XIcon />
               </button>
             </div>
@@ -1029,7 +1041,7 @@ export const Component = () => {
           <div style={{ padding: "20px 24px" }}>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20 }}>
               <div style={{ fontWeight: 700, fontSize: 17 }}>Edit Application</div>
-              <button onClick={() => setEditApp(null)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}><XIcon /></button>
+              <button onClick={() => setEditApp(null)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }} aria-label="Close modal"><XIcon /></button>
             </div>
 
             <div style={{ marginBottom: 14 }}>
@@ -1109,7 +1121,7 @@ export const Component = () => {
           <div style={{ padding: "20px 24px" }}>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20 }}>
               <div style={{ fontWeight: 700, fontSize: 17 }}>Settings</div>
-              <button onClick={() => setShowSettings(false)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}><XIcon /></button>
+              <button onClick={() => setShowSettings(false)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }} aria-label="Close settings"><XIcon /></button>
             </div>
 
             {[


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to various icon-only buttons in `job_tracker_component.tsx` and `habit_tracker_component.tsx` (such as delete, clear sort/filter, search, settings, and modal close buttons).

🎯 Why: To improve screen reader accessibility so users depending on assistive tech can interact with icon-only controls.

📸 Before/After: Visual presentation is not changed, only the DOM contains accessibility labels.

♿ Accessibility: Ensures that interactive elements without visible text provide descriptive accessible names, making the UI robust for all users.

---
*PR created automatically by Jules for task [7598988288869948107](https://jules.google.com/task/7598988288869948107) started by @aryankumar06*