### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-18 - Icon-only Buttons Accessibility
+**Learning:** Icon-only buttons without `aria-label` and `title` are an accessibility issue because screen readers cannot announce their purpose and mouse users don't get tooltip hints.
+**Action:** Always ensure that icon-only buttons have both an `aria-label` for screen readers and a `title` for mouse users to improve overall accessibility.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -71,6 +71,7 @@ const NotionCheckbox = ({ checked, onToggle, dark }) => (
     type="button"
     onClick={onToggle}
     aria-label={checked ? "Uncheck" : "Check"}
+    title={checked ? "Uncheck" : "Check"}
     className={cn(
       "w-[18px] h-[18px] rounded-[4px] border flex items-center justify-center transition-all duration-150 flex-shrink-0",
       dark
@@ -93,7 +94,7 @@ const Modal = ({ title, onClose, dark, children }) => {
       <div className={cn("w-full max-w-md rounded-xl border shadow-2xl", modal)}>
         <div className="flex items-center justify-between px-5 py-4 border-b" style={{ borderColor: divCol }}>
           <h2 className={cn("font-semibold text-base", titleCls)}>{title}</h2>
-          <button onClick={onClose} className={cn("p-1.5 rounded-md transition-colors", closeCls)}>
+          <button onClick={onClose} title="Close" aria-label="Close" className={cn("p-1.5 rounded-md transition-colors", closeCls)}>
             <X className="w-4 h-4" />
           </button>
         </div>
@@ -318,13 +319,13 @@ export const Component = () => {
                   {filterConfig && (
                     <div className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium", t.pill)}>
                       <Filter className="w-3 h-3" />Filtered
-                      <button onClick={() => setFilterConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
+                      <button onClick={() => setFilterConfig(null)} title="Clear filter" aria-label="Clear filter" className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
                     </div>
                   )}
                   {sortConfig && (
                     <div className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium", t.pill)}>
                       <ArrowUpDown className="w-3 h-3" />Sorted
-                      <button onClick={() => setSortConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
+                      <button onClick={() => setSortConfig(null)} title="Clear sort" aria-label="Clear sort" className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
                     </div>
                   )}
                 </div>
@@ -334,6 +335,7 @@ export const Component = () => {
                 {/* Filter */}
                 <div className="relative" ref={filterRef}>
                   <button onClick={() => { setShowFilterMenu(!showFilterMenu); setShowSortMenu(false); }}
+                    title="Filter" aria-label="Filter"
                     className={cn("p-2 rounded-md transition-colors", t.iconBtn, filterConfig ? t.pill : t.subtext)}>
                     <Filter className="w-4 h-4" />
                   </button>
@@ -354,6 +356,7 @@ export const Component = () => {
                 {/* Sort */}
                 <div className="relative" ref={sortRef}>
                   <button onClick={() => { setShowSortMenu(!showSortMenu); setShowFilterMenu(false); }}
+                    title="Sort" aria-label="Sort"
                     className={cn("p-2 rounded-md transition-colors", t.iconBtn, sortConfig ? t.pill : t.subtext)}>
                     <ArrowUpDown className="w-4 h-4" />
                   </button>
@@ -373,25 +376,28 @@ export const Component = () => {
                 </div>
 
                 {/* Zap: toggle all */}
-                <button onClick={handleToggleAll} title="Toggle all habits"
+                <button onClick={handleToggleAll} title="Toggle all habits" aria-label="Toggle all habits"
                   className={cn("p-2 rounded-md transition-colors", t.iconBtn, t.subtext)}>
                   <Zap className="w-4 h-4" />
                 </button>
 
                 {/* Search */}
                 <button onClick={() => { setShowSearch(!showSearch); if (showSearch) setSearchQuery(""); }}
+                  title="Search" aria-label="Search"
                   className={cn("p-2 rounded-md transition-colors", t.iconBtn, showSearch ? t.pill : t.subtext)}>
                   <Search className="w-4 h-4" />
                 </button>
 
                 {/* Settings */}
                 <button onClick={() => setShowSettingsModal(true)}
+                  title="Settings" aria-label="Settings"
                   className={cn("p-2 rounded-md transition-colors", t.iconBtn, t.subtext)}>
                   <Settings className="w-4 h-4" />
                 </button>
 
                 {/* Theme */}
                 <button onClick={() => setDark(!dark)}
+                  title="Toggle theme"
                   className={cn("p-2 rounded-md border transition-all duration-200", t.toggleBg, t.border)} aria-label="Toggle theme">
                   {dark ? <Sun className="w-4 h-4 text-yellow-400" /> : <Moon className={cn("w-4 h-4", t.subtext)} />}
                 </button>
@@ -438,6 +444,7 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
+                          title="Column options" aria-label="Column options"
                           className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
                         >
                           <ChevronDown className="w-3 h-3" />
@@ -459,7 +466,7 @@ export const Component = () => {
                     </th>
                   ))}
                   <th className={cn("px-4 py-3 text-center border-r w-12", t.subtext, t.cellBorder)}>
-                    <button onClick={() => setShowAddColumnModal(true)} title="Add column"
+                    <button onClick={() => setShowAddColumnModal(true)} title="Add column" aria-label="Add column"
                       className={cn("p-1 rounded transition-colors mx-auto block", t.iconBtn)}>
                       <Plus className="w-3.5 h-3.5" />
                     </button>
@@ -487,7 +494,7 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
+                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day" aria-label="Check all for this day"
                           className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
@@ -497,6 +504,7 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
+                            title="Row options" aria-label="Row options"
                             className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
@@ -579,6 +587,7 @@ export const Component = () => {
                   <div className="w-8 flex justify-center relative">
                     <button
                       onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
+                      title="Row options" aria-label="Row options"
                       className={cn("p-1 rounded transition-colors", t.iconBtn, t.muted)}
                     >
                       <MoreHorizontal className="w-4 h-4" />
@@ -697,13 +706,13 @@ export const Component = () => {
                       <span className={cn("text-sm", col.visible ? t.text : t.muted)}>{col.label}</span>
                     </div>
                     <div className="flex items-center gap-1">
-                      <button onClick={() => handleToggleColumnVis(col.key)} title={col.visible ? "Hide" : "Show"}
+                      <button onClick={() => handleToggleColumnVis(col.key)} title={col.visible ? "Hide" : "Show"} aria-label={col.visible ? "Hide column" : "Show column"}
                         className={cn("p-1.5 rounded transition-colors", t.iconBtn)}>
                         {col.visible
                           ? <Eye className={cn("w-3.5 h-3.5", t.subtext)} />
                           : <EyeOff className={cn("w-3.5 h-3.5", t.muted)} />}
                       </button>
-                      <button onClick={() => handleDeleteColumn(col.key)}
+                      <button onClick={() => handleDeleteColumn(col.key)} title="Delete column" aria-label="Delete column"
                         className={cn("p-1.5 rounded transition-colors", dark ? "hover:bg-red-900/20 text-red-400" : "hover:bg-red-50 text-red-500")}>
                         <Trash2 className="w-3.5 h-3.5" />
                       </button>


### PR DESCRIPTION
💡 What: Added missing `title` and `aria-label` attributes to icon-only buttons throughout the Habit Tracker component.
🎯 Why: To improve accessibility so screen readers can announce their purpose, and to provide tooltip hints for mouse users.
♿ Accessibility: Ensures that interactive elements lacking visible text are identifiable by assistive technologies.

---
*PR created automatically by Jules for task [8321096148508652140](https://jules.google.com/task/8321096148508652140) started by @aryankumar06*