### PR TITLE
🎨 Palette: Add aria-labels and titles to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Missing Accessible Labels on Icon-Only Actions
+**Learning:** Discovered a consistent pattern across multiple components (`job_tracker_component.tsx`, `habit_tracker_component.tsx`) where icon-only buttons used for secondary actions (closing modals, clearing filters, opening dropdowns) lacked `aria-label` and `title` attributes. This makes these common actions invisible to screen readers and difficult to discover for sighted users needing tooltips.
+**Action:** Always ensure that icon-only interactive elements receive both an `aria-label` for screen readers and a `title` attribute for tooltips as part of the standard component implementation checklist, especially for clear/close/filter controls.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -93,7 +93,7 @@ const Modal = ({ title, onClose, dark, children }) => {
       <div className={cn("w-full max-w-md rounded-xl border shadow-2xl", modal)}>
         <div className="flex items-center justify-between px-5 py-4 border-b" style={{ borderColor: divCol }}>
           <h2 className={cn("font-semibold text-base", titleCls)}>{title}</h2>
-          <button onClick={onClose} className={cn("p-1.5 rounded-md transition-colors", closeCls)}>
+          <button onClick={onClose} className={cn("p-1.5 rounded-md transition-colors", closeCls)} aria-label="Close modal" title="Close modal">
             <X className="w-4 h-4" />
           </button>
         </div>
@@ -318,13 +318,13 @@ export const Component = () => {
                   {filterConfig && (
                     <div className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium", t.pill)}>
                       <Filter className="w-3 h-3" />Filtered
-                      <button onClick={() => setFilterConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
+                      <button onClick={() => setFilterConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100" aria-label="Clear filter" title="Clear filter"><X className="w-3 h-3" /></button>
                     </div>
                   )}
                   {sortConfig && (
                     <div className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium", t.pill)}>
                       <ArrowUpDown className="w-3 h-3" />Sorted
-                      <button onClick={() => setSortConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
+                      <button onClick={() => setSortConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100" aria-label="Clear sort" title="Clear sort"><X className="w-3 h-3" /></button>
                     </div>
                   )}
                 </div>
@@ -334,7 +334,7 @@ export const Component = () => {
                 {/* Filter */}
                 <div className="relative" ref={filterRef}>
                   <button onClick={() => { setShowFilterMenu(!showFilterMenu); setShowSortMenu(false); }}
-                    className={cn("p-2 rounded-md transition-colors", t.iconBtn, filterConfig ? t.pill : t.subtext)}>
+                    className={cn("p-2 rounded-md transition-colors", t.iconBtn, filterConfig ? t.pill : t.subtext)} aria-label="Filter" title="Filter">
                     <Filter className="w-4 h-4" />
                   </button>
                   {showFilterMenu && (
@@ -354,7 +354,7 @@ export const Component = () => {
                 {/* Sort */}
                 <div className="relative" ref={sortRef}>
                   <button onClick={() => { setShowSortMenu(!showSortMenu); setShowFilterMenu(false); }}
-                    className={cn("p-2 rounded-md transition-colors", t.iconBtn, sortConfig ? t.pill : t.subtext)}>
+                    className={cn("p-2 rounded-md transition-colors", t.iconBtn, sortConfig ? t.pill : t.subtext)} aria-label="Sort" title="Sort">
                     <ArrowUpDown className="w-4 h-4" />
                   </button>
                   {showSortMenu && (
@@ -380,13 +380,13 @@ export const Component = () => {
 
                 {/* Search */}
                 <button onClick={() => { setShowSearch(!showSearch); if (showSearch) setSearchQuery(""); }}
-                  className={cn("p-2 rounded-md transition-colors", t.iconBtn, showSearch ? t.pill : t.subtext)}>
+                  className={cn("p-2 rounded-md transition-colors", t.iconBtn, showSearch ? t.pill : t.subtext)} aria-label="Search" title="Search">
                   <Search className="w-4 h-4" />
                 </button>
 
                 {/* Settings */}
                 <button onClick={() => setShowSettingsModal(true)}
-                  className={cn("p-2 rounded-md transition-colors", t.iconBtn, t.subtext)}>
+                  className={cn("p-2 rounded-md transition-colors", t.iconBtn, t.subtext)} aria-label="Settings" title="Settings">
                   <Settings className="w-4 h-4" />
                 </button>
 
@@ -439,6 +439,8 @@ export const Component = () => {
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
                           className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          aria-label="Column menu"
+                          title="Column menu"
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -498,6 +500,8 @@ export const Component = () => {
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
                             className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            aria-label="Row menu"
+                            title="Row menu"
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>
@@ -704,7 +708,7 @@ export const Component = () => {
                           : <EyeOff className={cn("w-3.5 h-3.5", t.muted)} />}
                       </button>
                       <button onClick={() => handleDeleteColumn(col.key)}
-                        className={cn("p-1.5 rounded transition-colors", dark ? "hover:bg-red-900/20 text-red-400" : "hover:bg-red-50 text-red-500")}>
+                        className={cn("p-1.5 rounded transition-colors", dark ? "hover:bg-red-900/20 text-red-400" : "hover:bg-red-50 text-red-500")} aria-label="Delete column" title="Delete column">
                         <Trash2 className="w-3.5 h-3.5" />
                       </button>
                     </div>

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -341,6 +341,8 @@ export const Component = () => {
                   <button
                     onClick={(e) => { e.preventDefault(); setResumeFile(null); }}
                     style={{ background: "none", border: "none", cursor: "pointer", color: t.muted, padding: 2 }}
+                    aria-label="Remove resume"
+                    title="Remove resume"
                   >
                     <XIcon size={12} />
                   </button>
@@ -621,6 +623,8 @@ export const Component = () => {
                 <button
                   onClick={() => setSearchQuery("")}
                   style={{ position: "absolute", right: 8, top: "50%", transform: "translateY(-50%)", background: "none", border: "none", cursor: "pointer", color: t.muted }}
+                  aria-label="Clear search"
+                  title="Clear search"
                 >
                   <XIcon size={13} />
                 </button>
@@ -638,7 +642,7 @@ export const Component = () => {
                   display: "flex", alignItems: "center", gap: 6,
                 }}>
                   Stage: {STAGES.find((s) => s.key === filterStage)?.label}
-                  <button onClick={() => setFilterStage("all")} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
+                  <button onClick={() => setFilterStage("all")} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }} aria-label="Clear stage filter" title="Clear stage filter">×</button>
                 </span>
               )}
               {sortField !== "none" && (
@@ -648,7 +652,7 @@ export const Component = () => {
                   display: "flex", alignItems: "center", gap: 6,
                 }}>
                   Sort: {sortField} {sortDir === "asc" ? "↑" : "↓"}
-                  <button onClick={clearSort} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
+                  <button onClick={clearSort} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }} aria-label="Clear sort" title="Clear sort">×</button>
                 </span>
               )}
             </div>
@@ -933,7 +937,7 @@ export const Component = () => {
                   <div style={{ fontSize: 13, color: t.muted }}>{selectedApp.role}</div>
                 </div>
               </div>
-              <button onClick={() => setSelectedApp(null)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}>
+              <button onClick={() => setSelectedApp(null)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }} aria-label="Close details" title="Close details">
                 <XIcon />
               </button>
             </div>
@@ -1029,7 +1033,7 @@ export const Component = () => {
           <div style={{ padding: "20px 24px" }}>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20 }}>
               <div style={{ fontWeight: 700, fontSize: 17 }}>Edit Application</div>
-              <button onClick={() => setEditApp(null)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}><XIcon /></button>
+              <button onClick={() => setEditApp(null)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }} aria-label="Close modal" title="Close modal"><XIcon /></button>
             </div>
 
             <div style={{ marginBottom: 14 }}>
@@ -1109,7 +1113,7 @@ export const Component = () => {
           <div style={{ padding: "20px 24px" }}>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20 }}>
               <div style={{ fontWeight: 700, fontSize: 17 }}>Settings</div>
-              <button onClick={() => setShowSettings(false)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}><XIcon /></button>
+              <button onClick={() => setShowSettings(false)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }} aria-label="Close modal" title="Close modal"><XIcon /></button>
             </div>
 
             {[


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to icon-only buttons across `job_tracker_component.tsx` and `habit_tracker_component.tsx`. Also added a `.Jules/palette.md` journal entry noting this learning.
🎯 Why: Icon-only buttons without accessible labels are invisible to screen readers and difficult to discover for sighted users who rely on tooltips. This improves both accessibility and general usability.
📸 Before/After: Visual changes are nil, but tooltips now appear on hover for these icon-only buttons.
♿ Accessibility: Ensures that close buttons, clear buttons, and menu triggers are properly announced to screen reader users.

---
*PR created automatically by Jules for task [15265130430047648921](https://jules.google.com/task/15265130430047648921) started by @aryankumar06*