### PR TITLE
🎨 Palette: Add `title` and `aria-label` to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-05-16 - Icon-Only Buttons Accessibility
+
+**Learning:** When using icon-only buttons (like those found in toolbars), providing just `aria-label` is not enough for all users, as sighted users might need tooltips to understand the icon's purpose. Conversely, providing just `title` doesn't always translate well to all screen readers.
+
+**Action:** Always include both `aria-label` (for screen readers) and `title` (for visual tooltips) on all icon-only buttons to ensure a consistently accessible and intuitive experience across all interaction modes.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -334,6 +334,7 @@ export const Component = () => {
                 {/* Filter */}
                 <div className="relative" ref={filterRef}>
                   <button onClick={() => { setShowFilterMenu(!showFilterMenu); setShowSortMenu(false); }}
+                    title="Filter" aria-label="Filter habits"
                     className={cn("p-2 rounded-md transition-colors", t.iconBtn, filterConfig ? t.pill : t.subtext)}>
                     <Filter className="w-4 h-4" />
                   </button>
@@ -354,6 +355,7 @@ export const Component = () => {
                 {/* Sort */}
                 <div className="relative" ref={sortRef}>
                   <button onClick={() => { setShowSortMenu(!showSortMenu); setShowFilterMenu(false); }}
+                    title="Sort" aria-label="Sort habits"
                     className={cn("p-2 rounded-md transition-colors", t.iconBtn, sortConfig ? t.pill : t.subtext)}>
                     <ArrowUpDown className="w-4 h-4" />
                   </button>
@@ -373,26 +375,29 @@ export const Component = () => {
                 </div>
 
                 {/* Zap: toggle all */}
-                <button onClick={handleToggleAll} title="Toggle all habits"
+                <button onClick={handleToggleAll} title="Toggle all habits" aria-label="Toggle all habits"
                   className={cn("p-2 rounded-md transition-colors", t.iconBtn, t.subtext)}>
                   <Zap className="w-4 h-4" />
                 </button>
 
                 {/* Search */}
                 <button onClick={() => { setShowSearch(!showSearch); if (showSearch) setSearchQuery(""); }}
+                  title="Search" aria-label="Search days"
                   className={cn("p-2 rounded-md transition-colors", t.iconBtn, showSearch ? t.pill : t.subtext)}>
                   <Search className="w-4 h-4" />
                 </button>
 
                 {/* Settings */}
                 <button onClick={() => setShowSettingsModal(true)}
+                  title="Settings" aria-label="Settings"
                   className={cn("p-2 rounded-md transition-colors", t.iconBtn, t.subtext)}>
                   <Settings className="w-4 h-4" />
                 </button>
 
                 {/* Theme */}
                 <button onClick={() => setDark(!dark)}
-                  className={cn("p-2 rounded-md border transition-all duration-200", t.toggleBg, t.border)} aria-label="Toggle theme">
+                  title="Toggle theme" aria-label="Toggle theme"
+                  className={cn("p-2 rounded-md border transition-all duration-200", t.toggleBg, t.border)}>
                   {dark ? <Sun className="w-4 h-4 text-yellow-400" /> : <Moon className={cn("w-4 h-4", t.subtext)} />}
                 </button>
 


### PR DESCRIPTION
💡 What: Added both `title` and `aria-label` attributes to the toolbar's icon-only buttons (Filter, Sort, Toggle All, Search, Settings, Theme) in `habit_tracker_component.tsx`.

🎯 Why: Ensures that these actions are accessible to screen readers while also providing helpful visual tooltips for sighted users.

📸 Before/After: Several buttons only had either a title or an aria-label, now all main toolbar actions are fully accessible and discoverable.

♿ Accessibility: Significantly improves keyboard and screen-reader accessibility for the main component controls.

---
*PR created automatically by Jules for task [8475199039172979547](https://jules.google.com/task/8475199039172979547) started by @aryankumar06*