### PR TITLE
🎨 Palette: Enhance icon-only buttons with ARIA labels and tooltips

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
+**Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
+**Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -334,6 +334,7 @@ export const Component = () => {
                 {/* Filter */}
                 <div className="relative" ref={filterRef}>
                   <button onClick={() => { setShowFilterMenu(!showFilterMenu); setShowSortMenu(false); }}
+                    aria-label="Filter habits" title="Filter habits"
                     className={cn("p-2 rounded-md transition-colors", t.iconBtn, filterConfig ? t.pill : t.subtext)}>
                     <Filter className="w-4 h-4" />
                   </button>
@@ -354,6 +355,7 @@ export const Component = () => {
                 {/* Sort */}
                 <div className="relative" ref={sortRef}>
                   <button onClick={() => { setShowSortMenu(!showSortMenu); setShowFilterMenu(false); }}
+                    aria-label="Sort habits" title="Sort habits"
                     className={cn("p-2 rounded-md transition-colors", t.iconBtn, sortConfig ? t.pill : t.subtext)}>
                     <ArrowUpDown className="w-4 h-4" />
                   </button>
@@ -373,26 +375,29 @@ export const Component = () => {
                 </div>
 
                 {/* Zap: toggle all */}
-                <button onClick={handleToggleAll} title="Toggle all habits"
+                <button onClick={handleToggleAll} aria-label="Toggle all habits" title="Toggle all habits"
                   className={cn("p-2 rounded-md transition-colors", t.iconBtn, t.subtext)}>
                   <Zap className="w-4 h-4" />
                 </button>
 
                 {/* Search */}
                 <button onClick={() => { setShowSearch(!showSearch); if (showSearch) setSearchQuery(""); }}
+                  aria-label="Search habits" title="Search habits"
                   className={cn("p-2 rounded-md transition-colors", t.iconBtn, showSearch ? t.pill : t.subtext)}>
                   <Search className="w-4 h-4" />
                 </button>
 
                 {/* Settings */}
                 <button onClick={() => setShowSettingsModal(true)}
+                  aria-label="Settings" title="Settings"
                   className={cn("p-2 rounded-md transition-colors", t.iconBtn, t.subtext)}>
                   <Settings className="w-4 h-4" />
                 </button>
 
                 {/* Theme */}
                 <button onClick={() => setDark(!dark)}
-                  className={cn("p-2 rounded-md border transition-all duration-200", t.toggleBg, t.border)} aria-label="Toggle theme">
+                  aria-label="Toggle theme" title="Toggle theme"
+                  className={cn("p-2 rounded-md border transition-all duration-200", t.toggleBg, t.border)}>
                   {dark ? <Sun className="w-4 h-4 text-yellow-400" /> : <Moon className={cn("w-4 h-4", t.subtext)} />}
                 </button>
 


### PR DESCRIPTION
Adds explicitly defined `aria-label` and `title` attributes to the Filter, Sort, Zap, Search, Settings, and Theme toggle icon-only buttons in `habit_tracker_component.tsx`. Also added a UX journal entry explaining this interaction pattern for accessibility.

---
*PR created automatically by Jules for task [14901187180751120055](https://jules.google.com/task/14901187180751120055) started by @aryankumar06*