### PR TITLE
🎨 Palette: Add ARIA labels and titles to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+## 2026-05-19 - Icon-Only Button Accessibility Pattern
+**Learning:** Across the components in this application (such as habit_tracker_component and job_tracker_component), there is a recurring pattern of icon-only action buttons (e.g., clear buttons, modal close, table menus) missing essential `aria-label` and `title` attributes. This makes them inaccessible to screen readers and difficult for all users to understand without tooltips.
+**Action:** Always verify that every icon-only button within tables, modals, and toolbars includes both an `aria-label` for screen readers and a `title` for visual tooltips, to ensure full accessibility and a better user experience.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -93,7 +93,7 @@ const Modal = ({ title, onClose, dark, children }) => {
       <div className={cn("w-full max-w-md rounded-xl border shadow-2xl", modal)}>
         <div className="flex items-center justify-between px-5 py-4 border-b" style={{ borderColor: divCol }}>
           <h2 className={cn("font-semibold text-base", titleCls)}>{title}</h2>
-          <button onClick={onClose} className={cn("p-1.5 rounded-md transition-colors", closeCls)}>
+          <button onClick={onClose} aria-label="Close modal" title="Close modal" className={cn("p-1.5 rounded-md transition-colors", closeCls)}>
             <X className="w-4 h-4" />
           </button>
         </div>
@@ -318,13 +318,13 @@ export const Component = () => {
                   {filterConfig && (
                     <div className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium", t.pill)}>
                       <Filter className="w-3 h-3" />Filtered
-                      <button onClick={() => setFilterConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
+                      <button onClick={() => setFilterConfig(null)} aria-label="Clear filter" title="Clear filter" className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
                     </div>
                   )}
                   {sortConfig && (
                     <div className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium", t.pill)}>
                       <ArrowUpDown className="w-3 h-3" />Sorted
-                      <button onClick={() => setSortConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
+                      <button onClick={() => setSortConfig(null)} aria-label="Clear sort" title="Clear sort" className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
                     </div>
                   )}
                 </div>
@@ -443,6 +443,8 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
+                          aria-label="Column menu"
+                          title="Column menu"
                           className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
                         >
                           <ChevronDown className="w-3 h-3" />
@@ -464,7 +466,7 @@ export const Component = () => {
                     </th>
                   ))}
                   <th className={cn("px-4 py-3 text-center border-r w-12", t.subtext, t.cellBorder)}>
-                    <button onClick={() => setShowAddColumnModal(true)} title="Add column"
+                    <button onClick={() => setShowAddColumnModal(true)} aria-label="Add column" title="Add column"
                       className={cn("p-1 rounded transition-colors mx-auto block", t.iconBtn)}>
                       <Plus className="w-3.5 h-3.5" />
                     </button>
@@ -492,7 +494,7 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
+                        <button onClick={() => handleCheckAllForDay(row.day)} aria-label="Check all for this day" title="Check all for this day"
                           className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
@@ -502,6 +504,8 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
+                            aria-label="Row menu"
+                            title="Row menu"
                             className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
@@ -584,6 +588,8 @@ export const Component = () => {
                   <div className="w-8 flex justify-center relative">
                     <button
                       onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
+                      aria-label="Row menu"
+                      title="Row menu"
                       className={cn("p-1 rounded transition-colors", t.iconBtn, t.muted)}
                     >
                       <MoreHorizontal className="w-4 h-4" />
@@ -702,13 +708,15 @@ export const Component = () => {
                       <span className={cn("text-sm", col.visible ? t.text : t.muted)}>{col.label}</span>
                     </div>
                     <div className="flex items-center gap-1">
-                      <button onClick={() => handleToggleColumnVis(col.key)} title={col.visible ? "Hide" : "Show"}
+                      <button onClick={() => handleToggleColumnVis(col.key)} aria-label={col.visible ? "Hide" : "Show"} title={col.visible ? "Hide" : "Show"}
                         className={cn("p-1.5 rounded transition-colors", t.iconBtn)}>
                         {col.visible
                           ? <Eye className={cn("w-3.5 h-3.5", t.subtext)} />
                           : <EyeOff className={cn("w-3.5 h-3.5", t.muted)} />}
                       </button>
                       <button onClick={() => handleDeleteColumn(col.key)}
+                        aria-label="Delete column"
+                        title="Delete column"
                         className={cn("p-1.5 rounded transition-colors", dark ? "hover:bg-red-900/20 text-red-400" : "hover:bg-red-50 text-red-500")}>
                         <Trash2 className="w-3.5 h-3.5" />
                       </button>

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -1,9 +1,11 @@
-npx shadcn@latest add https://21st.dev/r/aryankumar06/job-application-tracker-notion-style
+// npx shadcn@latest add https://21st.dev/r/aryankumar06/job-application-tracker-notion-style
+/*
 import { Component } from "@/components/ui/job-application-tracker-notion-style";
 
 export default function DemoOne() {
   return <Component />;
 }
+*/
 
 import { cn } from "@/lib/utils";
 import { useState, useRef, useEffect } from "react";
@@ -340,6 +342,8 @@ export const Component = () => {
                   <span>📄</span> {resumeFile}
                   <button
                     onClick={(e) => { e.preventDefault(); setResumeFile(null); }}
+                    aria-label="Clear resume file"
+                    title="Clear resume file"
                     style={{ background: "none", border: "none", cursor: "pointer", color: t.muted, padding: 2 }}
                   >
                     <XIcon size={12} />
@@ -638,7 +642,7 @@ export const Component = () => {
                   display: "flex", alignItems: "center", gap: 6,
                 }}>
                   Stage: {STAGES.find((s) => s.key === filterStage)?.label}
-                  <button onClick={() => setFilterStage("all")} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
+                  <button onClick={() => setFilterStage("all")} aria-label="Clear filter" title="Clear filter" style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
                 </span>
               )}
               {sortField !== "none" && (
@@ -648,7 +652,7 @@ export const Component = () => {
                   display: "flex", alignItems: "center", gap: 6,
                 }}>
                   Sort: {sortField} {sortDir === "asc" ? "↑" : "↓"}
-                  <button onClick={clearSort} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
+                  <button onClick={clearSort} aria-label="Clear sort" title="Clear sort" style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
                 </span>
               )}
             </div>
@@ -826,6 +830,7 @@ export const Component = () => {
                     <div style={{ display: "flex", gap: 4 }} onClick={(e) => e.stopPropagation()}>
                       <button
                         onClick={() => setEditApp({ ...app })}
+                        aria-label="Edit"
                         style={{ background: t.surfaceAlt, border: "none", borderRadius: 5, width: 28, height: 28, cursor: "pointer", color: t.muted, display: "flex", alignItems: "center", justifyContent: "center" }}
                         title="Edit"
                       >
@@ -833,6 +838,7 @@ export const Component = () => {
                       </button>
                       <button
                         onClick={() => deleteApp(app.id)}
+                        aria-label="Delete"
                         style={{ background: t.surfaceAlt, border: "none", borderRadius: 5, width: 28, height: 28, cursor: "pointer", color: "#ef4444", display: "flex", alignItems: "center", justifyContent: "center" }}
                         title="Delete"
                       >
@@ -881,6 +887,7 @@ export const Component = () => {
                 <span style={{ flex: 1, textDecoration: item.done ? "line-through" : "none" }}>{item.text}</span>
                 <button
                   onClick={() => deleteAction(item.id)}
+                  aria-label="Delete"
                   style={{ background: "none", border: "none", cursor: "pointer", color: t.subtle, padding: 4, display: "flex", alignItems: "center", borderRadius: 4, transition: "color 0.15s" }}
                   onMouseEnter={(e) => (e.currentTarget.style.color = "#ef4444")}
                   onMouseLeave={(e) => (e.currentTarget.style.color = t.subtle)}
@@ -933,7 +940,7 @@ export const Component = () => {
                   <div style={{ fontSize: 13, color: t.muted }}>{selectedApp.role}</div>
                 </div>
               </div>
-              <button onClick={() => setSelectedApp(null)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}>
+              <button onClick={() => setSelectedApp(null)} aria-label="Close modal" title="Close modal" style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}>
                 <XIcon />
               </button>
             </div>
@@ -1029,7 +1036,7 @@ export const Component = () => {
           <div style={{ padding: "20px 24px" }}>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20 }}>
               <div style={{ fontWeight: 700, fontSize: 17 }}>Edit Application</div>
-              <button onClick={() => setEditApp(null)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}><XIcon /></button>
+              <button onClick={() => setEditApp(null)} aria-label="Close modal" title="Close modal" style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}><XIcon /></button>
             </div>
 
             <div style={{ marginBottom: 14 }}>
@@ -1109,7 +1116,7 @@ export const Component = () => {
           <div style={{ padding: "20px 24px" }}>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20 }}>
               <div style={{ fontWeight: 700, fontSize: 17 }}>Settings</div>
-              <button onClick={() => setShowSettings(false)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}><XIcon /></button>
+              <button onClick={() => setShowSettings(false)} aria-label="Close modal" title="Close modal" style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}><XIcon /></button>
             </div>
 
             {[


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to numerous icon-only buttons across `habit_tracker_component.tsx` and `job_tracker_component.tsx`. Also commented out invalid `npx` command at the top of `job_tracker_component.tsx` that was causing syntax errors.
🎯 Why: To improve accessibility for screen readers and usability for sighted users by providing hover tooltips for icon-only actions like clearing inputs, closing modals, and editing items.
♿ Accessibility: Ensures that screen reader users can understand the purpose of all interactive buttons within the tables, modals, and toolbars.

---
*PR created automatically by Jules for task [877165399857310091](https://jules.google.com/task/877165399857310091) started by @aryankumar06*