### PR TITLE
🎨 Palette: Improve icon button accessibility in Habit Tracker

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2026-05-21 - Dual Accessibility Attributes for Icon-Only Buttons
+**Learning:** Found that many interactive icon-only buttons lacked both `aria-label` and `title` attributes, severely impacting both screen reader users and sighted users needing tooltips. This is a common pattern in components utilizing Lucide icons where visual context is assumed to be sufficient.
+**Action:** Always proactively add both `aria-label` and `title` to icon-only buttons to ensure full accessibility and a better UX.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -93,7 +93,7 @@ const Modal = ({ title, onClose, dark, children }) => {
       <div className={cn("w-full max-w-md rounded-xl border shadow-2xl", modal)}>
         <div className="flex items-center justify-between px-5 py-4 border-b" style={{ borderColor: divCol }}>
           <h2 className={cn("font-semibold text-base", titleCls)}>{title}</h2>
-          <button onClick={onClose} className={cn("p-1.5 rounded-md transition-colors", closeCls)}>
+          <button onClick={onClose} aria-label="Close modal" title="Close modal" className={cn("p-1.5 rounded-md transition-colors", closeCls)}>
             <X className="w-4 h-4" />
           </button>
         </div>
@@ -318,13 +318,13 @@ export const Component = () => {
                   {filterConfig && (
                     <div className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium", t.pill)}>
                       <Filter className="w-3 h-3" />Filtered
-                      <button onClick={() => setFilterConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
+                      <button onClick={() => setFilterConfig(null)} aria-label="Clear filter" title="Clear filter" className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
                     </div>
                   )}
                   {sortConfig && (
                     <div className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium", t.pill)}>
                       <ArrowUpDown className="w-3 h-3" />Sorted
-                      <button onClick={() => setSortConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
+                      <button onClick={() => setSortConfig(null)} aria-label="Clear sort" title="Clear sort" className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
                     </div>
                   )}
                 </div>
@@ -443,6 +443,7 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
+                          aria-label="Column menu" title="Column menu"
                           className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
                         >
                           <ChevronDown className="w-3 h-3" />
@@ -492,7 +493,7 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
+                        <button onClick={() => handleCheckAllForDay(row.day)} aria-label="Check all for this day" title="Check all for this day"
                           className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
@@ -502,6 +503,7 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
+                            aria-label="Row menu" title="Row menu"
                             className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
@@ -584,6 +586,7 @@ export const Component = () => {
                   <div className="w-8 flex justify-center relative">
                     <button
                       onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
+                      aria-label="Row menu" title="Row menu"
                       className={cn("p-1 rounded transition-colors", t.iconBtn, t.muted)}
                     >
                       <MoreHorizontal className="w-4 h-4" />
@@ -702,13 +705,13 @@ export const Component = () => {
                       <span className={cn("text-sm", col.visible ? t.text : t.muted)}>{col.label}</span>
                     </div>
                     <div className="flex items-center gap-1">
-                      <button onClick={() => handleToggleColumnVis(col.key)} title={col.visible ? "Hide" : "Show"}
+                      <button onClick={() => handleToggleColumnVis(col.key)} aria-label={col.visible ? "Hide column" : "Show column"} title={col.visible ? "Hide" : "Show"}
                         className={cn("p-1.5 rounded transition-colors", t.iconBtn)}>
                         {col.visible
                           ? <Eye className={cn("w-3.5 h-3.5", t.subtext)} />
                           : <EyeOff className={cn("w-3.5 h-3.5", t.muted)} />}
                       </button>
-                      <button onClick={() => handleDeleteColumn(col.key)}
+                      <button onClick={() => handleDeleteColumn(col.key)} aria-label="Delete column" title="Delete column"
                         className={cn("p-1.5 rounded transition-colors", dark ? "hover:bg-red-900/20 text-red-400" : "hover:bg-red-50 text-red-500")}>
                         <Trash2 className="w-3.5 h-3.5" />
                       </button>


### PR DESCRIPTION
💡 **What**: Added `aria-label` and `title` attributes to multiple icon-only buttons (like Close Modal, Filter, Sort, Row Menu, Check All, Eye, Trash) in `habit_tracker_component.tsx`. Also added a journal entry in `.Jules/palette.md`.
🎯 **Why**: Icon-only buttons provide zero context to screen reader users and can be ambiguous to sighted users. Adding these attributes significantly improves the accessibility and usability of dense UIs like the habit tracker.
📸 **Before/After**: No visual layout changes, but native browser tooltips now appear when hovering over icons, and assistive technologies correctly announce the button's purpose.
♿ **Accessibility**: Enhanced screen reader compatibility and semantic clarity by explicitly labelling all interactive icon components.

---
*PR created automatically by Jules for task [5157839859684277949](https://jules.google.com/task/5157839859684277949) started by @aryankumar06*