### PR TITLE
🎨 Palette: Improve disabled states and button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-05-25 - Explanatory Tooltips and Visual Styling for Disabled States
+**Learning:** Setting the `disabled` property on a button inherently prevents users from clicking it, but without appropriate visual indicators (opacity, not-allowed cursor) and explanatory context (tooltips explaining *why* it's disabled), users can be left feeling confused or stuck, especially when form validation prevents submission.
+**Action:** Whenever a button is dynamically disabled due to missing input or validation states, ensure the button's design communicates it's disabled via styling (`opacity-50`, `cursor-not-allowed`) and add a dynamically assigned `title` attribute to explain what the user needs to do to enable it.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -285,7 +285,7 @@ export const Component = () => {
 
   const inputCls = cn("w-full px-3 py-2 rounded-lg border text-sm outline-none transition-colors", t.input);
   const labelCls = cn("block text-xs font-medium mb-1.5", t.subtext);
-  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors", t.newBtn);
+  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed", t.newBtn);
   const secondaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium transition-colors border",
     dark ? "border-[#333] text-gray-300 hover:bg-[#1d1d1d]" : "border-gray-300 text-gray-600 hover:bg-gray-50");
 
@@ -663,7 +663,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowAddColumnModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} className={primaryBtn}>Add Column</button>
+              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} title={!newColLabel.trim() ? "Column name is required" : "Add column"} className={primaryBtn}>Add Column</button>
             </div>
           </div>
         </Modal>
@@ -682,7 +682,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowNewRowModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddRow} disabled={!newRowDay.trim()} className={primaryBtn}>Add Row</button>
+              <button onClick={handleAddRow} disabled={!newRowDay.trim()} title={!newRowDay.trim() ? "Row label is required" : "Add row"} className={primaryBtn}>Add Row</button>
             </div>
           </div>
         </Modal>
@@ -709,6 +709,7 @@ export const Component = () => {
                           : <EyeOff className={cn("w-3.5 h-3.5", t.muted)} />}
                       </button>
                       <button onClick={() => handleDeleteColumn(col.key)}
+                        aria-label="Delete column" title="Delete column"
                         className={cn("p-1.5 rounded transition-colors", dark ? "hover:bg-red-900/20 text-red-400" : "hover:bg-red-50 text-red-500")}>
                         <Trash2 className="w-3.5 h-3.5" />
                       </button>


### PR DESCRIPTION
💡 What: Added visual disabled styles (`opacity-50`, `cursor-not-allowed`) to primary buttons. Added dynamic tooltips explaining *why* buttons are disabled. Added missing `aria-label` and `title` to an icon-only delete button. Added learning journal entry.
🎯 Why: Disabled buttons without visual feedback or tooltips leave users confused about why an action is unavailable. Icon-only buttons without `aria-label` and `title` are inaccessible to screen readers and sighted users needing clarification.
♿ Accessibility: Improved screen reader support for icon-only button and clarified disabled states.

---
*PR created automatically by Jules for task [7960811097336368302](https://jules.google.com/task/7960811097336368302) started by @aryankumar06*