### PR TITLE
🎨 Palette: Enhance disabled button states and add tooltips

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2026-05-23 - Dynamic Tooltips for Disabled Buttons
+**Learning:** Providing visual styling (like `disabled:opacity-50`) isn't enough when buttons are disabled. Users often don't know *why* an action isn't available. Adding dynamic `title` tooltips that explain the specific missing requirement (e.g., 'Column name is required') significantly reduces user frustration.
+**Action:** Whenever implementing disabled states on forms or inputs, always pair them with an explanatory tooltip that dynamically informs the user what action is required to enable the button.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -93,7 +93,7 @@ const Modal = ({ title, onClose, dark, children }) => {
       <div className={cn("w-full max-w-md rounded-xl border shadow-2xl", modal)}>
         <div className="flex items-center justify-between px-5 py-4 border-b" style={{ borderColor: divCol }}>
           <h2 className={cn("font-semibold text-base", titleCls)}>{title}</h2>
-          <button onClick={onClose} className={cn("p-1.5 rounded-md transition-colors", closeCls)}>
+          <button onClick={onClose} aria-label="Close" title="Close" className={cn("p-1.5 rounded-md transition-colors", closeCls)}>
             <X className="w-4 h-4" />
           </button>
         </div>
@@ -260,7 +260,7 @@ export const Component = () => {
     header: "bg-[#171717]", rowHover: "hover:bg-[#1a1a1a]",
     text: "text-white", subtext: "text-gray-400", muted: "text-gray-500",
     tag: "bg-[#1d1d1d]", tagText: "text-gray-300",
-    iconBtn: "hover:bg-[#1d1d1d]", newBtn: "bg-[#2f6fed] hover:bg-[#275fe0]",
+    iconBtn: "hover:bg-[#1d1d1d]", newBtn: "bg-[#2f6fed] hover:bg-[#275fe0] disabled:opacity-50 disabled:cursor-not-allowed",
     dayText: "text-[#e6e6e6]", progressBg: "bg-[#2a2a2a]", progressFill: "bg-[#2f6fed]",
     cellBorder: "border-[#2a2a2a]", toggleBg: "bg-[#1d1d1d] hover:bg-[#2a2a2a] border-[#3a3a3a]",
     input: "bg-[#111] border-[#333] text-white placeholder-gray-600 focus:border-[#2f6fed]",
@@ -273,7 +273,7 @@ export const Component = () => {
     header: "bg-[#fafafa]", rowHover: "hover:bg-[#f9f9f9]",
     text: "text-[#1a1a1a]", subtext: "text-[#6b6b6b]", muted: "text-[#aaaaaa]",
     tag: "bg-[#f0f0ee]", tagText: "text-[#555]",
-    iconBtn: "hover:bg-[#f0f0f0]", newBtn: "bg-[#2f6fed] hover:bg-[#275fe0]",
+    iconBtn: "hover:bg-[#f0f0f0]", newBtn: "bg-[#2f6fed] hover:bg-[#275fe0] disabled:opacity-50 disabled:cursor-not-allowed",
     dayText: "text-[#2a2a2a]", progressBg: "bg-[#e8e8e8]", progressFill: "bg-[#2f6fed]",
     cellBorder: "border-[#e8e8e8]", toggleBg: "bg-[#f0f0ee] hover:bg-[#e8e8e6] border-[#e0e0e0]",
     input: "bg-white border-gray-300 text-gray-900 placeholder-gray-400 focus:border-[#2f6fed]",
@@ -318,13 +318,13 @@ export const Component = () => {
                   {filterConfig && (
                     <div className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium", t.pill)}>
                       <Filter className="w-3 h-3" />Filtered
-                      <button onClick={() => setFilterConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
+                      <button aria-label="Clear filter" title="Clear filter" onClick={() => setFilterConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
                     </div>
                   )}
                   {sortConfig && (
                     <div className={cn("inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border text-xs font-medium", t.pill)}>
                       <ArrowUpDown className="w-3 h-3" />Sorted
-                      <button onClick={() => setSortConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
+                      <button aria-label="Clear sort" title="Clear sort" onClick={() => setSortConfig(null)} className="ml-0.5 opacity-60 hover:opacity-100"><X className="w-3 h-3" /></button>
                     </div>
                   )}
                 </div>
@@ -663,7 +663,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowAddColumnModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} className={primaryBtn}>Add Column</button>
+              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} title={!newColLabel.trim() ? "Column name is required" : "Add Column"} className={primaryBtn}>Add Column</button>
             </div>
           </div>
         </Modal>
@@ -682,7 +682,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowNewRowModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddRow} disabled={!newRowDay.trim()} className={primaryBtn}>Add Row</button>
+              <button onClick={handleAddRow} disabled={!newRowDay.trim()} title={!newRowDay.trim() ? "Row label is required" : "Add Row"} className={primaryBtn}>Add Row</button>
             </div>
           </div>
         </Modal>


### PR DESCRIPTION
🎨 Palette: Enhance disabled button states and tooltips

💡 **What:**
- Added `disabled:opacity-50 disabled:cursor-not-allowed` styles to primary button theme variables.
- Added dynamic `title` tooltips to the "Add Column" and "Add Row" submit buttons that explain *why* the button is disabled.
- Added `aria-label` and `title` to the Modal Close button and active filter/sort clear (`<X />`) buttons.

🎯 **Why:**
- Users need clear visual feedback when actions are disabled, and more importantly, they need to know *what is missing* to enable them. Dynamic tooltips solve this frustration perfectly.
- Icon-only buttons without accessible names or tooltips are invisible to screen readers and confusing to sighted users who might not recognize the icon immediately.

♿ **Accessibility:**
- Improved screen reader support for icon-only buttons via `aria-label`.
- Added visual clarity and native tooltips via `title` attributes.

---
*PR created automatically by Jules for task [17840837799456836086](https://jules.google.com/task/17840837799456836086) started by @aryankumar06*