### PR TITLE
🎨 Palette: Add visual indicators and tooltips for disabled buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-05-24 - Visual Indicators and Explanatory Tooltips for Disabled States
+**Learning:** Simply setting a button to `disabled` is often insufficient for a good user experience. Users need clear visual feedback (like reduced opacity or a `not-allowed` cursor) to quickly identify non-interactive elements. Furthermore, explaining *why* a button is disabled via dynamic tooltips (e.g., `title={!isValid ? "Reason" : undefined}`) significantly reduces user frustration and confusion when completing forms or adding new items.
+**Action:** When implementing disabled states, consistently add clear visual indicators (e.g., `disabled:opacity-50 disabled:cursor-not-allowed`) and provide context-specific explanatory tooltips using conditional `title` attributes.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -285,7 +285,7 @@ export const Component = () => {
 
   const inputCls = cn("w-full px-3 py-2 rounded-lg border text-sm outline-none transition-colors", t.input);
   const labelCls = cn("block text-xs font-medium mb-1.5", t.subtext);
-  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors", t.newBtn);
+  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed", t.newBtn);
   const secondaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium transition-colors border",
     dark ? "border-[#333] text-gray-300 hover:bg-[#1d1d1d]" : "border-gray-300 text-gray-600 hover:bg-gray-50");
 
@@ -663,7 +663,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowAddColumnModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} className={primaryBtn}>Add Column</button>
+              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} title={!newColLabel.trim() ? "Column name cannot be empty" : undefined} className={primaryBtn}>Add Column</button>
             </div>
           </div>
         </Modal>
@@ -682,7 +682,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowNewRowModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddRow} disabled={!newRowDay.trim()} className={primaryBtn}>Add Row</button>
+              <button onClick={handleAddRow} disabled={!newRowDay.trim()} title={!newRowDay.trim() ? "Row label cannot be empty" : undefined} className={primaryBtn}>Add Row</button>
             </div>
           </div>
         </Modal>


### PR DESCRIPTION
### 💡 What
Added visual disabled states (opacity and cursor changes) to primary buttons, and informative tooltips explaining *why* they are disabled on the "Add Column" and "Add Row" modals.

### 🎯 Why
Users were likely experiencing friction when clicking visually active but functionally disabled buttons. Adding clear visual cues (opacity reduction, not-allowed cursor) paired with descriptive tooltips ("Column name cannot be empty") removes the guesswork, improving overall intuition and reducing frustration.

### ♿ Accessibility
Improves accessibility by explicitly giving reason to screen readers via the `title` attribute, ensuring that when an element is disabled, the user understands the prerequisite action needed to enable it.

---
*PR created automatically by Jules for task [11845811737055972522](https://jules.google.com/task/11845811737055972522) started by @aryankumar06*