### PR TITLE
🎨 Palette: Enhance disabled button UX with tooltips and visual states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2026-05-25 - Disabled Button Feedback
+**Learning:** Users lack context when action buttons (like Add Row/Column) are disabled without visual cues or explanation.
+**Action:** Add `disabled:opacity-50 disabled:cursor-not-allowed` to button classes and dynamic `title` tooltips to explain the disabled state.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -285,7 +285,7 @@ export const Component = () => {
 
   const inputCls = cn("w-full px-3 py-2 rounded-lg border text-sm outline-none transition-colors", t.input);
   const labelCls = cn("block text-xs font-medium mb-1.5", t.subtext);
-  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors", t.newBtn);
+  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed", t.newBtn);
   const secondaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium transition-colors border",
     dark ? "border-[#333] text-gray-300 hover:bg-[#1d1d1d]" : "border-gray-300 text-gray-600 hover:bg-gray-50");
 
@@ -663,7 +663,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowAddColumnModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} className={primaryBtn}>Add Column</button>
+              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} className={primaryBtn} title={!newColLabel.trim() ? "Please enter a column name" : undefined}>Add Column</button>
             </div>
           </div>
         </Modal>
@@ -682,7 +682,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowNewRowModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddRow} disabled={!newRowDay.trim()} className={primaryBtn}>Add Row</button>
+              <button onClick={handleAddRow} disabled={!newRowDay.trim()} className={primaryBtn} title={!newRowDay.trim() ? "Please enter a row label" : undefined}>Add Row</button>
             </div>
           </div>
         </Modal>


### PR DESCRIPTION
**💡 What**: Added visual disabled states and explanatory tooltips to primary buttons in the habit tracker.
**🎯 Why**: When a user tries to click a disabled button, they need to know *why* it's disabled. A subtle tooltip solves this without disrupting the UI. Adding visual opacity/cursor changes makes it clear the button isn't broken, just inactive.
**♿ Accessibility**: Improves context for keyboard users and screen readers navigating to inactive buttons, while giving sighted users immediate visual feedback.

---
*PR created automatically by Jules for task [17834918961605913591](https://jules.google.com/task/17834918961605913591) started by @aryankumar06*