### PR TITLE
🎨 Palette: Add visual indicators and tooltips to disabled buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+## 2024-05-26 - Explanatory Tooltips on Disabled Buttons
+**Learning:** Disabled UI elements without explanation can cause user frustration as they try to figure out what step they missed. Just lowering opacity isn't enough; users need to know *why* an action is blocked.
+**Action:** When creating a disabled button state, always ensure there is a visual indicator (`disabled:opacity-50`, `disabled:cursor-not-allowed`) AND provide a dynamic `title` tooltip that explains what the user needs to do to enable the button.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -285,7 +285,7 @@ export const Component = () => {
 
   const inputCls = cn("w-full px-3 py-2 rounded-lg border text-sm outline-none transition-colors", t.input);
   const labelCls = cn("block text-xs font-medium mb-1.5", t.subtext);
-  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors", t.newBtn);
+  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed", t.newBtn);
   const secondaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium transition-colors border",
     dark ? "border-[#333] text-gray-300 hover:bg-[#1d1d1d]" : "border-gray-300 text-gray-600 hover:bg-gray-50");
 
@@ -663,7 +663,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowAddColumnModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} className={primaryBtn}>Add Column</button>
+              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} title={!newColLabel.trim() ? "Column name is required" : undefined} className={primaryBtn}>Add Column</button>
             </div>
           </div>
         </Modal>
@@ -682,7 +682,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowNewRowModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddRow} disabled={!newRowDay.trim()} className={primaryBtn}>Add Row</button>
+              <button onClick={handleAddRow} disabled={!newRowDay.trim()} title={!newRowDay.trim() ? "Row label is required" : undefined} className={primaryBtn}>Add Row</button>
             </div>
           </div>
         </Modal>


### PR DESCRIPTION
💡 What: Added visual disabled states (opacity and cursor changes) and explanatory tooltips to disabled primary buttons.
🎯 Why: Without visual indicators and explanations, users can get frustrated trying to figure out why an action (like adding a row or column) is blocked.
📸 Before/After: See Playwright screenshot/video.
♿ Accessibility: Improves understanding of UI state and provides actionable guidance.

---
*PR created automatically by Jules for task [12233359481084281294](https://jules.google.com/task/12233359481084281294) started by @aryankumar06*