### PR TITLE
🎨 Palette: Add visual disabled states and explanatory tooltips to modal buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+## 2026-05-27 - Disabled Button Tooltips
+**Learning:** When disabling primary actions (like submitting a form), providing a standard disabled visual state (`opacity-50`, `cursor-not-allowed`) is crucial. However, purely visual cues do not explain *why* an action is blocked. Adding a dynamic tooltip (`title`) that specifically states the missing requirement (e.g., "Column name is required") bridges this gap, significantly improving clarity for all users.
+**Action:** Always pair disabled button states with explanatory tooltips indicating exactly what the user must do to enable the button.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -285,7 +285,7 @@ export const Component = () => {
 
   const inputCls = cn("w-full px-3 py-2 rounded-lg border text-sm outline-none transition-colors", t.input);
   const labelCls = cn("block text-xs font-medium mb-1.5", t.subtext);
-  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors", t.newBtn);
+  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed", t.newBtn);
   const secondaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium transition-colors border",
     dark ? "border-[#333] text-gray-300 hover:bg-[#1d1d1d]" : "border-gray-300 text-gray-600 hover:bg-gray-50");
 
@@ -663,7 +663,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowAddColumnModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} className={primaryBtn}>Add Column</button>
+              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} className={primaryBtn} title={!newColLabel.trim() ? "Column name is required" : "Add Column"}>Add Column</button>
             </div>
           </div>
         </Modal>
@@ -682,7 +682,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowNewRowModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddRow} disabled={!newRowDay.trim()} className={primaryBtn}>Add Row</button>
+              <button onClick={handleAddRow} disabled={!newRowDay.trim()} className={primaryBtn} title={!newRowDay.trim() ? "Row label is required" : "Add Row"}>Add Row</button>
             </div>
           </div>
         </Modal>


### PR DESCRIPTION
💡 **What**: Added visual disabled states (`opacity-50`, `cursor-not-allowed`) to primary buttons and implemented dynamic tooltips on the "Add Column" and "Add Row" buttons to explain why they are disabled.

🎯 **Why**: Previously, primary buttons like "Add Column" in modals were technically disabled when inputs were empty, but there was no clear visual cue (like dimming or a blocked cursor) to indicate this. Furthermore, users were left guessing *why* the button was disabled. By adding an explanatory tooltip ("Column name is required"), we provide immediate, actionable feedback.

📸 **Before/After**: The button now dims when the input is empty and reveals a tooltip instructing the user on what is missing.

♿ **Accessibility**: The dynamic `title` attribute acts as a tooltip for sighted users and provides extra context to some assistive technologies, making the form requirements clearer without needing to rely on error messages after a failed submission.

---
*PR created automatically by Jules for task [16664586238584769888](https://jules.google.com/task/16664586238584769888) started by @aryankumar06*