### PR TITLE
🎨 Palette: Improve disabled button UX in modals

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+## 2024-06-25 - Disabled Button Tooltips
+**Learning:** Disabled buttons without visual indicators and explanations cause user confusion.
+**Action:** Always add visual indicators (`disabled:opacity-50 disabled:cursor-not-allowed`) and dynamic tooltips (`title` attribute) to disabled buttons to explain the required action.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -285,7 +285,7 @@ export const Component = () => {
 
   const inputCls = cn("w-full px-3 py-2 rounded-lg border text-sm outline-none transition-colors", t.input);
   const labelCls = cn("block text-xs font-medium mb-1.5", t.subtext);
-  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors", t.newBtn);
+  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed", t.newBtn);
   const secondaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium transition-colors border",
     dark ? "border-[#333] text-gray-300 hover:bg-[#1d1d1d]" : "border-gray-300 text-gray-600 hover:bg-gray-50");
 
@@ -663,7 +663,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowAddColumnModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} className={primaryBtn}>Add Column</button>
+              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} className={primaryBtn} title={!newColLabel.trim() ? "Column name is required" : "Add Column"}>Add Column</button>
             </div>
           </div>
         </Modal>
@@ -682,7 +682,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowNewRowModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddRow} disabled={!newRowDay.trim()} className={primaryBtn}>Add Row</button>
+              <button onClick={handleAddRow} disabled={!newRowDay.trim()} className={primaryBtn} title={!newRowDay.trim() ? "Label is required" : "Add Row"}>Add Row</button>
             </div>
           </div>
         </Modal>


### PR DESCRIPTION
💡 What: Added visual indicators (`disabled:opacity-50 disabled:cursor-not-allowed`) to the `primaryBtn` class and dynamic tooltips (`title` attribute) to the "Add Column" and "Add Row" disabled buttons in the modals.
🎯 Why: Users without context can be confused by inactive buttons. Providing clear visual disabled states and tooltips explains what is required to activate the buttons.
♿ Accessibility: Improved disabled state communication.

---
*PR created automatically by Jules for task [14791653007633699142](https://jules.google.com/task/14791653007633699142) started by @aryankumar06*