### PR TITLE
🎨 Palette: Informative Disabled States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2026-05-30 - Informative Disabled States
+**Learning:** Disabling buttons without explanation (e.g., opacity or tooltip) leads to user confusion as they don't know why an action is blocked. This pattern was observed on submit buttons across form modals in the application trackers.
+**Action:** Always provide a clear visual cue (like `opacity-50` and `cursor-not-allowed`) along with a dynamic `title` tooltip that explains exactly what is required to enable the button.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -285,7 +285,7 @@ export const Component = () => {
 
   const inputCls = cn("w-full px-3 py-2 rounded-lg border text-sm outline-none transition-colors", t.input);
   const labelCls = cn("block text-xs font-medium mb-1.5", t.subtext);
-  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors", t.newBtn);
+  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed", t.newBtn);
   const secondaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium transition-colors border",
     dark ? "border-[#333] text-gray-300 hover:bg-[#1d1d1d]" : "border-gray-300 text-gray-600 hover:bg-gray-50");
 
@@ -663,7 +663,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowAddColumnModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} className={primaryBtn}>Add Column</button>
+              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} title={!newColLabel.trim() ? "Please enter a column name" : "Add Column"} className={primaryBtn}>Add Column</button>
             </div>
           </div>
         </Modal>
@@ -682,7 +682,7 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowNewRowModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddRow} disabled={!newRowDay.trim()} className={primaryBtn}>Add Row</button>
+              <button onClick={handleAddRow} disabled={!newRowDay.trim()} title={!newRowDay.trim() ? "Please enter a row label" : "Add Row"} className={primaryBtn}>Add Row</button>
             </div>
           </div>
         </Modal>

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -1,8 +1,8 @@
-npx shadcn@latest add https://21st.dev/r/aryankumar06/job-application-tracker-notion-style
-import { Component } from "@/components/ui/job-application-tracker-notion-style";
+// npx shadcn@latest add https://21st.dev/r/aryankumar06/job-application-tracker-notion-style
+import { Component as JobTrackerComponent } from "@/components/ui/job-application-tracker-notion-style";
 
 export default function DemoOne() {
-  return <Component />;
+  return <JobTrackerComponent />;
 }
 
 import { cn } from "@/lib/utils";
@@ -738,7 +738,7 @@ export const Component = () => {
                         style={{ ...inputStyle, marginBottom: 8 }}
                       />
                       <div style={{ display: "flex", gap: 6 }}>
-                        <button onClick={() => addApp(stage.key)} style={{ flex: 1, background: "#3b82f6", color: "#fff", border: "none", borderRadius: 6, padding: "6px 0", fontSize: 13, cursor: "pointer", fontFamily: "inherit" }}>Add</button>
+                        <button onClick={() => addApp(stage.key)} disabled={!newAppName.trim()} title={!newAppName.trim() ? "Please enter a company name" : "Add"} style={{ flex: 1, background: "#3b82f6", color: "#fff", border: "none", borderRadius: 6, padding: "6px 0", fontSize: 13, cursor: !newAppName.trim() ? "not-allowed" : "pointer", opacity: !newAppName.trim() ? 0.5 : 1, fontFamily: "inherit" }}>Add</button>
                         <button onClick={() => { setAddingToStage(null); setNewAppName(""); setNewAppRole(""); }} style={{ flex: 1, background: t.surfaceAlt, color: t.muted, border: "none", borderRadius: 6, padding: "6px 0", fontSize: 13, cursor: "pointer", fontFamily: "inherit" }}>Cancel</button>
                       </div>
                     </div>
@@ -902,10 +902,13 @@ export const Component = () => {
             />
             <button
               onClick={addAction}
+              disabled={!newActionText.trim()}
+              title={!newActionText.trim() ? "Please enter an action item" : "Add"}
               style={{
                 background: "#3b82f6", color: "#fff", border: "none",
                 borderRadius: 6, padding: "7px 16px", fontSize: 13,
-                fontFamily: "inherit", fontWeight: 600, cursor: "pointer",
+                fontFamily: "inherit", fontWeight: 600, cursor: !newActionText.trim() ? "not-allowed" : "pointer",
+                opacity: !newActionText.trim() ? 0.5 : 1,
               }}
             >
               Add
@@ -1088,7 +1091,9 @@ export const Component = () => {
             <div style={{ display: "flex", gap: 8 }}>
               <button
                 onClick={saveEdit}
-                style={{ flex: 1, background: "#3b82f6", color: "#fff", border: "none", borderRadius: 7, padding: "9px 0", fontSize: 13, fontWeight: 600, cursor: "pointer", fontFamily: "inherit" }}
+                disabled={!editApp.company.trim()}
+                title={!editApp.company.trim() ? "Company name is required" : "Save changes"}
+                style={{ flex: 1, background: "#3b82f6", color: "#fff", border: "none", borderRadius: 7, padding: "9px 0", fontSize: 13, fontWeight: 600, cursor: !editApp.company.trim() ? "not-allowed" : "pointer", opacity: !editApp.company.trim() ? 0.5 : 1, fontFamily: "inherit" }}
               >
                 Save changes
               </button>


### PR DESCRIPTION
🎨 Palette: Informative Disabled States

💡 What: Added informative disabled states to form submit buttons in the habit and job trackers.
🎯 Why: Disabling buttons without explanation (e.g., opacity or tooltip) leads to user confusion as they don't know why an action is blocked.
♿ Accessibility: Added `title` tooltips explaining why a button is disabled, and visual cues (`opacity-50` and `cursor-not-allowed`) for clarity.

---
*PR created automatically by Jules for task [16588469961598342029](https://jules.google.com/task/16588469961598342029) started by @aryankumar06*