### PR TITLE
🎨 Palette: Add semantic buttons and a11y improvements to interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-05-18 - Semantic Buttons for Interactive Elements
+**Learning:** Users with screen readers or relying on keyboard navigation cannot focus or interpret `<div>` tags used as interactive elements (like the checkmarks or settings toggles).
+**Action:** Always use `<button type="button">` for custom clickable elements and supply context via `aria-label` or `aria-checked` to ensure accessibility and keyboard support.

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -1,8 +1,8 @@
-npx shadcn@latest add https://21st.dev/r/aryankumar06/job-application-tracker-notion-style
-import { Component } from "@/components/ui/job-application-tracker-notion-style";
+// npx shadcn@latest add https://21st.dev/r/aryankumar06/job-application-tracker-notion-style
+import { Component as JobTrackerComponent } from "@/components/ui/job-application-tracker-notion-style";
 
 export default function DemoOne() {
-  return <Component />;
+  return <JobTrackerComponent />;
 }
 
 import { cn } from "@/lib/utils";
@@ -866,7 +866,9 @@ export const Component = () => {
                   transition: "color 0.2s",
                 }}
               >
-                <div
+                <button
+                  type="button"
+                  aria-label={item.done ? "Mark as incomplete" : "Mark as complete"}
                   onClick={() => toggleAction(item.id)}
                   style={{
                     width: 18, height: 18, borderRadius: 4, flexShrink: 0,
@@ -877,9 +879,11 @@ export const Component = () => {
                   }}
                 >
                   {item.done && <CheckIcon />}
-                </div>
+                </button>
                 <span style={{ flex: 1, textDecoration: item.done ? "line-through" : "none" }}>{item.text}</span>
                 <button
+                  type="button"
+                  aria-label="Delete action item"
                   onClick={() => deleteAction(item.id)}
                   style={{ background: "none", border: "none", cursor: "pointer", color: t.subtle, padding: 4, display: "flex", alignItems: "center", borderRadius: 4, transition: "color 0.15s" }}
                   onMouseEnter={(e) => (e.currentTarget.style.color = "#ef4444")}
@@ -1121,11 +1125,16 @@ export const Component = () => {
                   <div style={{ fontSize: 14, fontWeight: 500 }}>{label}</div>
                   <div style={{ fontSize: 12, color: t.muted, marginTop: 2 }}>{desc}</div>
                 </div>
-                <div
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={value}
+                  aria-label={label}
                   onClick={() => set(!value)}
                   style={{
                     width: 42, height: 24, borderRadius: 12, cursor: "pointer",
                     background: value ? "#3b82f6" : t.border,
+                    border: "none",
                     position: "relative", transition: "background 0.2s", flexShrink: 0,
                   }}
                 >
@@ -1135,7 +1144,7 @@ export const Component = () => {
                     background: "#fff", transition: "left 0.2s",
                     boxShadow: "0 1px 3px rgba(0,0,0,0.3)",
                   }} />
-                </div>
+                </button>
               </div>
             ))}
 


### PR DESCRIPTION
💡 What: Replaced generic `<div>` tags with semantic `<button>` tags for action item checkmarks and settings toggles.
🎯 Why: Interactive elements using generic tags are largely invisible to screen readers and cannot be navigated using the keyboard (`tab`).
📸 Before/After: Visuals remained identical. Added semantic structures.
♿ Accessibility:
- Added `type="button"` and `aria-label` depending on state for the action item checkbox.
- Added `aria-label` for screen reader clarity to the delete action button.
- Replaced the settings `<div onClick>` with a `<button type="button" role="switch">` complete with `aria-checked` states.

---
*PR created automatically by Jules for task [1583391892808586492](https://jules.google.com/task/1583391892808586492) started by @aryankumar06*