### PR TITLE
🎨 Palette: Fix keyboard accessibility trap for hover buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-06-15 - Hidden Controls and Keyboard Accessibility
+**Learning:** Using `opacity-0 group-hover:opacity-100` to hide secondary action buttons in tables or lists creates an accessibility trap for keyboard users. These elements receive focus as the user tabs through the interface, but remain invisible, causing confusion about where the current focus is.
+**Action:** Always pair `opacity-0` hover reveals with `focus-visible:opacity-100` (and clear focus rings like `focus-visible:ring-2 outline-none`) so that keyboard navigation naturally reveals the hidden controls when they receive focus.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -443,7 +443,8 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          aria-label="Column actions" title="Column actions"
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-[#2f6fed] outline-none p-0.5 rounded transition-all", t.iconBtn)}
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -464,8 +465,8 @@ export const Component = () => {
                     </th>
                   ))}
                   <th className={cn("px-4 py-3 text-center border-r w-12", t.subtext, t.cellBorder)}>
-                    <button onClick={() => setShowAddColumnModal(true)} title="Add column"
-                      className={cn("p-1 rounded transition-colors mx-auto block", t.iconBtn)}>
+                    <button onClick={() => setShowAddColumnModal(true)} aria-label="Add column" title="Add column"
+                      className={cn("p-1 rounded transition-colors mx-auto block focus-visible:ring-2 focus-visible:ring-[#2f6fed] outline-none", t.iconBtn)}>
                       <Plus className="w-3.5 h-3.5" />
                     </button>
                   </th>
@@ -492,8 +493,8 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                        <button onClick={() => handleCheckAllForDay(row.day)} aria-label={`Check all habits for ${row.day}`} title={`Check all habits for ${row.day}`}
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-[#2f6fed] outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -502,7 +503,8 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            aria-label={`Row actions for ${row.day}`} title={`Row actions for ${row.day}`}
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-[#2f6fed] outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>
@@ -584,7 +586,8 @@ export const Component = () => {
                   <div className="w-8 flex justify-center relative">
                     <button
                       onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                      className={cn("p-1 rounded transition-colors", t.iconBtn, t.muted)}
+                      aria-label={`Row actions for ${row.day}`} title={`Row actions for ${row.day}`}
+                      className={cn("p-1 rounded transition-colors focus-visible:ring-2 focus-visible:ring-[#2f6fed] outline-none", t.iconBtn, t.muted)}
                     >
                       <MoreHorizontal className="w-4 h-4" />
                     </button>


### PR DESCRIPTION
💡 **What:** Added `focus-visible:opacity-100` and clear focus rings to 3 action buttons (column actions, row actions, check all row) that were previously hidden via `opacity-0` until hovered. Added missing `aria-label` and `title` attributes to make them screen-reader and tooltip friendly.
🎯 **Why:** Keyboard users tabbing through the table would focus on invisible elements, creating an accessibility trap and making it impossible to know where the focus was or what the buttons did.
📸 **Before/After:** The buttons now reveal themselves with a blue focus ring when focused via the keyboard.
♿ **Accessibility:** Solves a major keyboard trap (`WCAG 2.4.7 Focus Visible`) and missing accessible names (`WCAG 4.1.2 Name, Role, Value`). Added critical learning to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [1651775831438639002](https://jules.google.com/task/1651775831438639002) started by @aryankumar06*