### PR TITLE
🎨 Palette: Make hover-hidden buttons accessible via keyboard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+## 2024-05-24 - Focus Visibility for Hover-Hidden Elements
+**Learning:** Hiding interactive elements using `opacity-0 group-hover:opacity-100` creates a major accessibility trap for keyboard users, as the elements remain invisible even when they receive focus via the Tab key.
+**Action:** Always include `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none` alongside hover-based opacity changes to ensure buttons become visible and clearly outlined when navigated to via keyboard.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -442,8 +442,10 @@ export const Component = () => {
                         <col.icon className="w-3.5 h-3.5 flex-shrink-0" />
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
+                          aria-label="Column actions"
+                          title="Column actions"
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-0.5 rounded transition-all", t.iconBtn)}
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -492,8 +494,8 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                        <button onClick={() => handleCheckAllForDay(row.day)} aria-label="Check all for this day" title="Check all for this day"
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -501,8 +503,10 @@ export const Component = () => {
                       <td className="px-4 py-3.5 text-center relative">
                         <div className="relative inline-block">
                           <button
+                            aria-label="Row actions"
+                            title="Row actions"
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>


### PR DESCRIPTION
💡 **What:** Added `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none`, `aria-label`, and `title` attributes to the hover-revealed buttons (Column Actions, Check All, Row Actions) in the table. Documented the focus-visible requirement for hover-hidden elements in the Palette journal.
🎯 **Why:** Elements hidden with `opacity-0 group-hover:opacity-100` are invisible to keyboard users even when they receive focus via the Tab key, creating an accessibility trap. Adding `focus-visible` styles ensures they appear when tabbed to, and the ARIA labels provide context for screen readers.
♿ **Accessibility:** Solved a critical keyboard navigation visibility issue and improved screen reader context for icon-only action buttons.

---
*PR created automatically by Jules for task [3494525697938175217](https://jules.google.com/task/3494525697938175217) started by @aryankumar06*