### PR TITLE
🎨 Palette: Accessibility attributes for icon-only buttons

### DIFF
--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -1,4 +1,4 @@
-npx shadcn@latest add https://21st.dev/r/aryankumar06/job-application-tracker-notion-style
+// npx shadcn@latest add https://21st.dev/r/aryankumar06/job-application-tracker-notion-style
 import { Component } from "@/components/ui/job-application-tracker-notion-style";
 
 export default function DemoOne() {
@@ -340,6 +340,7 @@ export const Component = () => {
                   <span>📄</span> {resumeFile}
                   <button
                     onClick={(e) => { e.preventDefault(); setResumeFile(null); }}
+                    aria-label="Remove resume" title="Remove resume"
                     style={{ background: "none", border: "none", cursor: "pointer", color: t.muted, padding: 2 }}
                   >
                     <XIcon size={12} />
@@ -406,6 +407,7 @@ export const Component = () => {
               <div style={{ position: "relative" }} ref={filterMenuRef}>
                 <button
                   title="Filter by stage"
+                  aria-label="Filter by stage"
                   onClick={() => setShowFilterMenu((v) => !v)}
                   style={iconBtn(filterStage !== "all" || showFilterMenu)}
                 >
@@ -450,6 +452,7 @@ export const Component = () => {
               <div style={{ position: "relative" }} ref={sortMenuRef}>
                 <button
                   title="Sort"
+                  aria-label="Sort"
                   onClick={() => setShowSortMenu((v) => !v)}
                   style={iconBtn(sortField !== "none" || showSortMenu)}
                 >
@@ -507,6 +510,7 @@ export const Component = () => {
               {/* Search */}
               <button
                 title="Search"
+                aria-label="Search"
                 onClick={() => { setShowSearch((v) => !v); setTimeout(() => searchRef.current?.focus(), 50); }}
                 style={iconBtn(showSearch)}
               >
@@ -518,6 +522,7 @@ export const Component = () => {
               {/* Expand */}
               <button
                 title={isExpanded ? "Collapse" : "Expand"}
+                aria-label={isExpanded ? "Collapse" : "Expand"}
                 onClick={() => setIsExpanded((v) => !v)}
                 style={iconBtn(isExpanded)}
               >
@@ -532,6 +537,7 @@ export const Component = () => {
               {/* Settings */}
               <button
                 title="Settings"
+                aria-label="Settings"
                 onClick={() => setShowSettings(true)}
                 style={iconBtn(showSettings)}
               >
@@ -620,6 +626,7 @@ export const Component = () => {
               {searchQuery && (
                 <button
                   onClick={() => setSearchQuery("")}
+                  aria-label="Clear search" title="Clear search"
                   style={{ position: "absolute", right: 8, top: "50%", transform: "translateY(-50%)", background: "none", border: "none", cursor: "pointer", color: t.muted }}
                 >
                   <XIcon size={13} />
@@ -638,7 +645,7 @@ export const Component = () => {
                   display: "flex", alignItems: "center", gap: 6,
                 }}>
                   Stage: {STAGES.find((s) => s.key === filterStage)?.label}
-                  <button onClick={() => setFilterStage("all")} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
+                  <button onClick={() => setFilterStage("all")} aria-label="Clear filter" title="Clear filter" style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
                 </span>
               )}
               {sortField !== "none" && (
@@ -648,7 +655,7 @@ export const Component = () => {
                   display: "flex", alignItems: "center", gap: 6,
                 }}>
                   Sort: {sortField} {sortDir === "asc" ? "↑" : "↓"}
-                  <button onClick={clearSort} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
+                  <button onClick={clearSort} aria-label="Clear filter" title="Clear filter" style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
                 </span>
               )}
             </div>
@@ -827,6 +834,7 @@ export const Component = () => {
                       <button
                         onClick={() => setEditApp({ ...app })}
                         style={{ background: t.surfaceAlt, border: "none", borderRadius: 5, width: 28, height: 28, cursor: "pointer", color: t.muted, display: "flex", alignItems: "center", justifyContent: "center" }}
+                        aria-label="Edit"
                         title="Edit"
                       >
                         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg>
@@ -834,6 +842,7 @@ export const Component = () => {
                       <button
                         onClick={() => deleteApp(app.id)}
                         style={{ background: t.surfaceAlt, border: "none", borderRadius: 5, width: 28, height: 28, cursor: "pointer", color: "#ef4444", display: "flex", alignItems: "center", justifyContent: "center" }}
+                        aria-label="Delete"
                         title="Delete"
                       >
                         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="3 6 5 6 21 6" /><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" /><path d="M10 11v6M14 11v6" /><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" /></svg>
@@ -884,7 +893,8 @@ export const Component = () => {
                   style={{ background: "none", border: "none", cursor: "pointer", color: t.subtle, padding: 4, display: "flex", alignItems: "center", borderRadius: 4, transition: "color 0.15s" }}
                   onMouseEnter={(e) => (e.currentTarget.style.color = "#ef4444")}
                   onMouseLeave={(e) => (e.currentTarget.style.color = t.subtle)}
-                  title="Delete"
+                  aria-label="Delete action item"
+                  title="Delete action item"
                 >
                   <XIcon size={13} />
                 </button>
@@ -933,7 +943,7 @@ export const Component = () => {
                   <div style={{ fontSize: 13, color: t.muted }}>{selectedApp.role}</div>
                 </div>
               </div>
-              <button onClick={() => setSelectedApp(null)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}>
+              <button onClick={() => setSelectedApp(null)} aria-label="Close modal" title="Close modal" style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}>
                 <XIcon />
               </button>
             </div>
@@ -1029,7 +1039,7 @@ export const Component = () => {
           <div style={{ padding: "20px 24px" }}>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20 }}>
               <div style={{ fontWeight: 700, fontSize: 17 }}>Edit Application</div>
-              <button onClick={() => setEditApp(null)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}><XIcon /></button>
+              <button onClick={() => setEditApp(null)} aria-label="Close modal" title="Close modal" style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}><XIcon /></button>
             </div>
 
             <div style={{ marginBottom: 14 }}>
@@ -1109,7 +1119,7 @@ export const Component = () => {
           <div style={{ padding: "20px 24px" }}>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20 }}>
               <div style={{ fontWeight: 700, fontSize: 17 }}>Settings</div>
-              <button onClick={() => setShowSettings(false)} style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}><XIcon /></button>
+              <button onClick={() => setShowSettings(false)} aria-label="Close modal" title="Close modal" style={{ background: "none", border: "none", cursor: "pointer", color: t.muted }}><XIcon /></button>
             </div>
 
             {[


### PR DESCRIPTION
💡 **What**: Added explicit `aria-label` and `title` attributes to all icon-only buttons in the job tracker component.
🎯 **Why**: Ensures these buttons are properly announced by screen readers and provide visual tooltips on hover for sighted users, fixing a common accessibility gap in dense UIs.
♿ **Accessibility**: Improves keyboard and screen-reader accessibility for navigation, filtering, and CRUD operations.

---
*PR created automatically by Jules for task [2919880191836321581](https://jules.google.com/task/2919880191836321581) started by @aryankumar06*