### PR TITLE
🎨 Palette: Fix keyboard accessibility for hidden file upload input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-05-25 - Hidden File Inputs and Keyboard Navigation
+**Learning:** When hiding native `<input type="file" />` elements (`display: none`) and substituting them with custom styled `<label>` wrappers, keyboard accessibility is completely lost. Screen reader and keyboard-only users cannot focus or trigger the upload dialog.
+**Action:** Ensure custom wrapper `<label>` components around hidden file inputs have `tabIndex={0}`, an `onKeyDown` handler to trigger click via "Enter" and "Space" keys, and visible focus styles (e.g., via `onFocus` and `onBlur`).

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -319,6 +319,7 @@ export const Component = () => {
             ↓ Upload your resume by clicking the block below and choosing a file from your computer
           </p>
           <label
+            tabIndex={0}
             style={{
               display: "flex", alignItems: "center", gap: 12,
               background: t.surfaceAlt, border: `1px solid ${t.border}`,
@@ -328,6 +329,14 @@ export const Component = () => {
             }}
             onMouseEnter={(e) => (e.currentTarget.style.borderColor = "#3b82f6")}
             onMouseLeave={(e) => (e.currentTarget.style.borderColor = t.border)}
+            onFocus={(e) => (e.currentTarget.style.borderColor = "#3b82f6")}
+            onBlur={(e) => (e.currentTarget.style.borderColor = t.border)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.currentTarget.click();
+              }
+            }}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
@@ -339,6 +348,8 @@ export const Component = () => {
               ? <span style={{ color: t.text, display: "flex", alignItems: "center", gap: 8 }}>
                   <span>📄</span> {resumeFile}
                   <button
+                    aria-label="Remove resume"
+                    title="Remove resume"
                     onClick={(e) => { e.preventDefault(); setResumeFile(null); }}
                     style={{ background: "none", border: "none", cursor: "pointer", color: t.muted, padding: 2 }}
                   >


### PR DESCRIPTION
🎨 Palette: Fix keyboard accessibility for hidden file upload input

💡 What: Restored keyboard accessibility to the custom file upload component and added ARIA labels to the remove resume button.
🎯 Why: The native `<input type="file" />` is hidden, which removes it from the focus sequence, making it impossible for keyboard or screen reader users to upload a resume. The remove button was also lacking accessible text.
♿ Accessibility:
- Added `tabIndex={0}` to the wrapping `<label>`
- Added `onKeyDown` to trigger the upload via "Enter" and "Space"
- Added visible focus styling via `onFocus`/`onBlur`
- Added `aria-label` and `title` to the "Remove resume" button

---
*PR created automatically by Jules for task [6023982840313148471](https://jules.google.com/task/6023982840313148471) started by @aryankumar06*