### PR TITLE
🎨 Palette: Fix keyboard focus trap on hover-revealed buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-05-24 - Hover States and Keyboard Focus Traps
+**Learning:** UI elements hidden visually via hover states (e.g., `opacity-0 group-hover:opacity-100`) become inaccessible to keyboard users unless explicitly styled for focus. These keyboard traps prevent users from discovering or interacting with actions.
+**Action:** Always pair `opacity-0 group-hover:opacity-100` with `focus-visible:opacity-100` and clear focus rings (like `focus-visible:ring-2 focus-visible:outline-none`) to ensure keyboard navigability.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -443,7 +443,9 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          aria-label="Column actions"
+                          title="Column actions"
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-0.5 rounded transition-all", t.iconBtn)}
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -492,8 +494,8 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day" aria-label={`Check all for ${row.day}`}
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -502,7 +504,9 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            aria-label={`Row actions for ${row.day}`}
+                            title={`Row actions for ${row.day}`}
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>


### PR DESCRIPTION
### 💡 What
Added focus-visible styling (`focus-visible:opacity-100`, `focus-visible:ring-2`, `focus-visible:outline-none`) and explicit `aria-label` / `title` attributes to three icon-only action buttons in the Habit Tracker table (column menu, check-all cell, row menu). These buttons previously relied solely on mouse hover (`group-hover:opacity-100`) to become visible.

### 🎯 Why
UI elements hidden visually via hover states become a "keyboard trap" for non-mouse users. While users could potentially tab onto the buttons, they would remain invisible (`opacity-0`), making it impossible to know what action was focused or how to interact with it. By enforcing visibility on focus, we restore full accessibility to the table's advanced controls.

### ♿ Accessibility
- Fixed a major keyboard accessibility trap for tab navigation.
- Added contextual `aria-label`s (e.g. `aria-label="Row actions for Monday"`) and `title`s to generic Lucide icons so screen readers can interpret them appropriately.

---
*PR created automatically by Jules for task [1353042043017230410](https://jules.google.com/task/1353042043017230410) started by @aryankumar06*