### PR TITLE
🎨 Palette: Make hover-hidden table actions keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2026-06-12 - Keyboard accessibility for hover-hidden elements
+**Learning:** Hiding interactive elements using `opacity-0 group-hover:opacity-100` creates a keyboard accessibility trap. Screen reader and keyboard-only users cannot focus or interact with these elements because they remain invisible during tab navigation.
+**Action:** Whenever using `opacity-0 group-hover:opacity-100` on an interactive element, always combine it with `focus-visible:opacity-100` and provide a clear focus indicator like `focus-visible:ring-2 focus-visible:outline-none`.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -443,7 +443,9 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          title="Column menu"
+                          aria-label="Column menu"
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-0.5 rounded transition-all", t.iconBtn)}
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -492,8 +494,8 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day" aria-label="Check all for this day"
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -502,7 +504,9 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            title="Row menu"
+                            aria-label="Row menu"
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>


### PR DESCRIPTION
Fix keyboard accessibility trap for table actions (column menu, row menu, check all) that are normally hidden via hover states.

💡 What: Added `focus-visible:opacity-100`, `focus-visible:ring-2`, and `focus-visible:outline-none` to hover-hidden table icon buttons in `habit_tracker_component.tsx`. Also explicitly added `aria-label` and `title` attributes to them.
🎯 Why: Elements hidden via `opacity-0` but lacking focus states are inaccessible to keyboard and screen reader users as they navigate the UI via the `Tab` key, essentially becoming traps.
♿ Accessibility: Ensures that interactive table elements hidden on hover become visually visible and announced correctly when receiving keyboard focus. Also added a journal entry in `.Jules/palette.md` to document this learning.

---
*PR created automatically by Jules for task [14285608231999415705](https://jules.google.com/task/14285608231999415705) started by @aryankumar06*