### PR TITLE
🎨 Palette: Improve keyboard accessibility for hidden file input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-05-24 - Keyboard Accessibility for Hidden File Inputs
+**Learning:** When hiding standard `<input type="file">` elements (e.g., `display: none`) and replacing them with custom styled `<label>` elements for better UI, keyboard navigation is completely lost by default. The label doesn't naturally receive focus or respond to Enter/Space keys, creating a severe accessibility trap where keyboard users cannot upload files.
+**Action:** When styling custom file inputs by wrapping them in labels, always make the wrapper keyboard focusable (`tabIndex={0}`), visually indicate focus (`onFocus`/`onBlur` with `box-shadow` or `outline`), and add an `onKeyDown` handler to programmatically trigger the underlying file input when Enter or Space is pressed.

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -319,12 +319,22 @@ export const Component = () => {
             ↓ Upload your resume by clicking the block below and choosing a file from your computer
           </p>
           <label
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                const input = e.currentTarget.querySelector('input[type="file"]') as HTMLInputElement;
+                if (input) input.click();
+              }
+            }}
+            onFocus={(e) => (e.currentTarget.style.boxShadow = "0 0 0 2px #3b82f6")}
+            onBlur={(e) => (e.currentTarget.style.boxShadow = "none")}
             style={{
               display: "flex", alignItems: "center", gap: 12,
               background: t.surfaceAlt, border: `1px solid ${t.border}`,
               borderRadius: 8, padding: "16px 20px",
               fontSize: 14, color: t.muted, cursor: "pointer",
-              transition: "border-color 0.2s",
+              transition: "border-color 0.2s, box-shadow 0.2s",
             }}
             onMouseEnter={(e) => (e.currentTarget.style.borderColor = "#3b82f6")}
             onMouseLeave={(e) => (e.currentTarget.style.borderColor = t.border)}
@@ -339,6 +349,8 @@ export const Component = () => {
               ? <span style={{ color: t.text, display: "flex", alignItems: "center", gap: 8 }}>
                   <span>📄</span> {resumeFile}
                   <button
+                    aria-label="Remove uploaded resume"
+                    title="Remove uploaded resume"
                     onClick={(e) => { e.preventDefault(); setResumeFile(null); }}
                     style={{ background: "none", border: "none", cursor: "pointer", color: t.muted, padding: 2 }}
                   >


### PR DESCRIPTION
💡 What:
- Made the custom file upload `<label>` focusable with `tabIndex={0}`.
- Added `onKeyDown` to allow triggering the hidden file input with Enter or Space keys.
- Added a visual `boxShadow` focus state for keyboard navigation.
- Added explicit `aria-label` and `title` to the remove resume icon button.

🎯 Why:
When a standard file input is hidden (`display: none`) and replaced with a custom label, it completely breaks keyboard accessibility. Keyboard users cannot tab to the button or upload a file. The remove icon button also lacked screen reader labels and visual tooltips.

♿ Accessibility:
- Allows fully functional keyboard navigation and file uploading.
- Improves screen reader experience for removing uploaded files.

---
*PR created automatically by Jules for task [1787200509962738252](https://jules.google.com/task/1787200509962738252) started by @aryankumar06*