### PR TITLE
🎨 Palette: Add missing aria-labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+## 2024-05-24 - Accessibility on dynamically added structural elements
+**Learning:** In components with highly dynamic interactive elements (like close buttons on active filters or sorting rules), developers often skip adding `aria-label` because the element is small (like a single '×' character). This causes screen readers to read "button, X" which is unhelpful.
+**Action:** When auditing icon-only buttons, systematically check dynamic badges and dismissible structural elements for missing accessibility labels, not just the primary toolbar buttons.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -464,7 +464,7 @@ export const Component = () => {
                     </th>
                   ))}
                   <th className={cn("px-4 py-3 text-center border-r w-12", t.subtext, t.cellBorder)}>
-                    <button onClick={() => setShowAddColumnModal(true)} title="Add column"
+                    <button onClick={() => setShowAddColumnModal(true)} title="Add column" aria-label="Add column"
                       className={cn("p-1 rounded transition-colors mx-auto block", t.iconBtn)}>
                       <Plus className="w-3.5 h-3.5" />
                     </button>
@@ -492,7 +492,7 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
+                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day" aria-label="Check all for this day"
                           className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
@@ -703,6 +703,7 @@ export const Component = () => {
                     </div>
                     <div className="flex items-center gap-1">
                       <button onClick={() => handleToggleColumnVis(col.key)} title={col.visible ? "Hide" : "Show"}
+                        aria-label={col.visible ? "Hide" : "Show"}
                         className={cn("p-1.5 rounded transition-colors", t.iconBtn)}>
                         {col.visible
                           ? <Eye className={cn("w-3.5 h-3.5", t.subtext)} />

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -405,7 +405,7 @@ export const Component = () => {
               {/* Filter */}
               <div style={{ position: "relative" }} ref={filterMenuRef}>
                 <button
-                  title="Filter by stage"
+                  title="Filter by stage" aria-label="Filter by stage"
                   onClick={() => setShowFilterMenu((v) => !v)}
                   style={iconBtn(filterStage !== "all" || showFilterMenu)}
                 >
@@ -449,7 +449,7 @@ export const Component = () => {
               {/* Sort */}
               <div style={{ position: "relative" }} ref={sortMenuRef}>
                 <button
-                  title="Sort"
+                  title="Sort" aria-label="Sort"
                   onClick={() => setShowSortMenu((v) => !v)}
                   style={iconBtn(sortField !== "none" || showSortMenu)}
                 >
@@ -506,7 +506,7 @@ export const Component = () => {
 
               {/* Search */}
               <button
-                title="Search"
+                title="Search" aria-label="Search"
                 onClick={() => { setShowSearch((v) => !v); setTimeout(() => searchRef.current?.focus(), 50); }}
                 style={iconBtn(showSearch)}
               >
@@ -518,6 +518,7 @@ export const Component = () => {
               {/* Expand */}
               <button
                 title={isExpanded ? "Collapse" : "Expand"}
+                        aria-label={isExpanded ? "Collapse" : "Expand"}
                 onClick={() => setIsExpanded((v) => !v)}
                 style={iconBtn(isExpanded)}
               >
@@ -531,7 +532,7 @@ export const Component = () => {
 
               {/* Settings */}
               <button
-                title="Settings"
+                title="Settings" aria-label="Settings"
                 onClick={() => setShowSettings(true)}
                 style={iconBtn(showSettings)}
               >
@@ -638,7 +639,7 @@ export const Component = () => {
                   display: "flex", alignItems: "center", gap: 6,
                 }}>
                   Stage: {STAGES.find((s) => s.key === filterStage)?.label}
-                  <button onClick={() => setFilterStage("all")} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
+                  <button aria-label="Clear filter" onClick={() => setFilterStage("all")} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
                 </span>
               )}
               {sortField !== "none" && (
@@ -648,7 +649,7 @@ export const Component = () => {
                   display: "flex", alignItems: "center", gap: 6,
                 }}>
                   Sort: {sortField} {sortDir === "asc" ? "↑" : "↓"}
-                  <button onClick={clearSort} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
+                  <button aria-label="Clear sort" onClick={clearSort} style={{ background: "none", border: "none", cursor: "pointer", color: "inherit", padding: 0, lineHeight: 1 }}>×</button>
                 </span>
               )}
             </div>
@@ -827,14 +828,14 @@ export const Component = () => {
                       <button
                         onClick={() => setEditApp({ ...app })}
                         style={{ background: t.surfaceAlt, border: "none", borderRadius: 5, width: 28, height: 28, cursor: "pointer", color: t.muted, display: "flex", alignItems: "center", justifyContent: "center" }}
-                        title="Edit"
+                        title="Edit" aria-label="Edit"
                       >
                         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg>
                       </button>
                       <button
                         onClick={() => deleteApp(app.id)}
                         style={{ background: t.surfaceAlt, border: "none", borderRadius: 5, width: 28, height: 28, cursor: "pointer", color: "#ef4444", display: "flex", alignItems: "center", justifyContent: "center" }}
-                        title="Delete"
+                        title="Delete" aria-label="Delete"
                       >
                         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="3 6 5 6 21 6" /><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" /><path d="M10 11v6M14 11v6" /><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" /></svg>
                       </button>
@@ -884,7 +885,7 @@ export const Component = () => {
                   style={{ background: "none", border: "none", cursor: "pointer", color: t.subtle, padding: 4, display: "flex", alignItems: "center", borderRadius: 4, transition: "color 0.15s" }}
                   onMouseEnter={(e) => (e.currentTarget.style.color = "#ef4444")}
                   onMouseLeave={(e) => (e.currentTarget.style.color = t.subtle)}
-                  title="Delete"
+                  title="Delete" aria-label="Delete"
                 >
                   <XIcon size={13} />
                 </button>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to all icon-only buttons across the habit and job tracker components (e.g., Edit, Delete, Filter, Sort, Settings, Search, Add Column, etc). Also added aria-labels to the small '×' buttons used for clearing filters/sorting.
🎯 Why: Screen reader users need descriptive labels to understand what icon-only buttons do. Previously these buttons only had `title` tooltips for sighted users.
♿ Accessibility: Ensures all interactive icon buttons have explicit, accessible names for screen readers, preventing them from reading "button" or generic characters.

---
*PR created automatically by Jules for task [4471495273247373747](https://jules.google.com/task/4471495273247373747) started by @aryankumar06*