### PR TITLE
🎨 Palette: Make hover-hidden actions and disabled buttons accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,10 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+## 2024-05-18 - Hover-only buttons trap keyboard users
+**Learning:** Using `opacity-0 group-hover:opacity-100` makes buttons completely invisible to keyboard users who tab through the interface, creating a significant accessibility barrier.
+**Action:** Always pair `group-hover:opacity-100` with `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none` so elements become visible and show a clear ring when they receive keyboard focus.
+
+## 2024-05-18 - Disabled states need explanation
+**Learning:** A visually disabled button (`opacity-50 cursor-not-allowed`) alone doesn't tell the user *why* it's disabled or what they need to do to enable it.
+**Action:** Add dynamic `title` attributes to disabled buttons (e.g., `title={!input ? "Please enter a value" : undefined}`) to provide explanatory tooltips on hover/focus.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -285,7 +285,7 @@ export const Component = () => {
 
   const inputCls = cn("w-full px-3 py-2 rounded-lg border text-sm outline-none transition-colors", t.input);
   const labelCls = cn("block text-xs font-medium mb-1.5", t.subtext);
-  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors", t.newBtn);
+  const primaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed", t.newBtn);
   const secondaryBtn = cn("px-4 py-2 rounded-lg text-sm font-medium transition-colors border",
     dark ? "border-[#333] text-gray-300 hover:bg-[#1d1d1d]" : "border-gray-300 text-gray-600 hover:bg-gray-50");
 
@@ -443,7 +443,9 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          aria-label="Column menu"
+                          title="Column menu"
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-0.5 rounded transition-all", t.iconBtn)}
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -492,8 +494,8 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                        <button onClick={() => handleCheckAllForDay(row.day)} title={`Check all for ${row.day}`} aria-label={`Check all for ${row.day}`}
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -502,7 +504,9 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            aria-label={`Row menu for ${row.day}`}
+                            title={`Row menu for ${row.day}`}
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>
@@ -663,7 +667,9 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowAddColumnModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddColumn} disabled={!newColLabel.trim()} className={primaryBtn}>Add Column</button>
+              <span title={!newColLabel.trim() ? "Please enter a column name" : undefined}>
+                <button onClick={handleAddColumn} disabled={!newColLabel.trim()} className={primaryBtn}>Add Column</button>
+              </span>
             </div>
           </div>
         </Modal>
@@ -682,7 +688,9 @@ export const Component = () => {
             </div>
             <div className="flex justify-end gap-2 pt-1">
               <button onClick={() => setShowNewRowModal(false)} className={secondaryBtn}>Cancel</button>
-              <button onClick={handleAddRow} disabled={!newRowDay.trim()} className={primaryBtn}>Add Row</button>
+              <span title={!newRowDay.trim() ? "Please enter a row label" : undefined}>
+                <button onClick={handleAddRow} disabled={!newRowDay.trim()} className={primaryBtn}>Add Row</button>
+              </span>
             </div>
           </div>
         </Modal>


### PR DESCRIPTION
💡 **What**:
- Improved keyboard accessibility for hover-hidden action buttons by adding `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none`.
- Added `aria-label` and `title` to these icon-only buttons for screen readers and tooltips.
- Added visual indicators for disabled primary buttons (`opacity-50 cursor-not-allowed`).
- Added a dynamic tooltip to the disabled buttons (wrapped in `span`) indicating what input is missing.
- Added a journal entry to `.Jules/palette.md` to document the learnings about hover accessibility traps and disabled button tooltips.

🎯 **Why**:
- Previously, buttons hidden by `opacity-0 group-hover:opacity-100` were invisible when focused via keyboard (Tab), making the table's actions inaccessible to keyboard users.
- Missing ARIA labels meant screen readers couldn't identify the purpose of the icon-only buttons.
- A button that is disabled without visual indication or explanation causes frustration and confusion for the user. Adding the visual state and an explanatory tooltip provides immediate clarity.

♿ **Accessibility**:
- Resolved keyboard focus traps.
- Provided missing ARIA properties.
- Enhanced UX clarity for disabled states.

---
*PR created automatically by Jules for task [1960881112364364101](https://jules.google.com/task/1960881112364364101) started by @aryankumar06*