### PR TITLE
🎨 Palette: Fix keyboard accessibility traps for hidden menu actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+## 2025-02-28 - Keyboard Traps in Hover-Hidden Elements
+**Learning:** Hiding UI elements like menus or actions behind `opacity-0 group-hover:opacity-100` without focus styling prevents keyboard users from discovering and accessing these elements.
+**Action:** Always include `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none` (or similar focus-visible states) alongside hover states for elements that only appear on hover, and ensure they have appropriate `aria-label`/`title` attributes.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -443,7 +443,9 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-0.5 rounded transition-all", t.iconBtn)}
+                          aria-label="Column options"
+                          title="Column options"
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -492,8 +494,8 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day" aria-label="Check all for this day"
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -502,7 +504,9 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            aria-label="Row options"
+                            title="Row options"
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>


### PR DESCRIPTION
💡 **What:** Added keyboard focus visibility and ARIA labels to hover-hidden icon buttons in the data grid.
🎯 **Why:** Elements hidden behind hover states (`opacity-0 group-hover:opacity-100`) were acting as keyboard accessibility traps because they were undiscoverable and unusable via keyboard navigation or screen readers.
📸 **Before/After:** No visual changes for mouse users, but keyboard users can now tab into these previously invisible buttons.
♿ **Accessibility:** Added `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none` alongside proper `aria-label` and `title` attributes.

---
*PR created automatically by Jules for task [5421722674341766378](https://jules.google.com/task/5421722674341766378) started by @aryankumar06*