### PR TITLE
🎨 Palette: Fix keyboard accessibility trap on hover-hidden buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2025-02-18 - Keyboard Accessibility Trap with Hover States
+**Learning:** Hiding interactive elements using `opacity-0 group-hover:opacity-100` without focus styles creates a keyboard accessibility trap. Keyboard users can focus these elements but won't see them, leading to confusion.
+**Action:** Always pair hover visibility classes with focus visibility classes (e.g., `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none`) to ensure elements become visible when receiving keyboard focus.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -443,7 +443,8 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-0.5 rounded transition-all", t.iconBtn)}
+                          aria-label={`Column menu for ${col.label}`} title={`Column menu for ${col.label}`}
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -492,8 +493,8 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                        <button onClick={() => handleCheckAllForDay(row.day)} title={`Check all for ${row.day}`} aria-label={`Check all for ${row.day}`}
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -502,7 +503,8 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            aria-label={`Row menu for ${row.day}`} title={`Row menu for ${row.day}`}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>


### PR DESCRIPTION
💡 What: Added focus-visible styles (`focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none`) and proper `aria-label`/`title` attributes to three icon-only action buttons (row menu, column menu, and check-all) in the habit tracker component.
🎯 Why: The buttons were previously hidden using `opacity-0 group-hover:opacity-100`, which created a keyboard accessibility trap. Keyboard users could tab to the elements but wouldn't see them or know what action they perform, leading to a confusing and inaccessible experience.
♿ Accessibility: Ensures that interactive elements hidden behind hover states become visible when receiving keyboard focus, and adds essential context for screen readers and tooltips for sighted users.

---
*PR created automatically by Jules for task [9423794850044344021](https://jules.google.com/task/9423794850044344021) started by @aryankumar06*