### PR TITLE
🎨 Palette: Fix keyboard accessibility trap for hover-only elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-06-18 - Keyboard Accessibility Trap with Hover-Only Visibility
+**Learning:** Hiding interactive UI elements behind hover states (e.g., `opacity-0 group-hover:opacity-100`) completely hides them from keyboard users who navigate via the Tab key, creating an accessibility trap where features become mouse-exclusive.
+**Action:** Always include `focus-visible:opacity-100` and clear focus rings (e.g., `focus-visible:ring-2 focus-visible:outline-none`) when using hover-based visibility classes, ensuring keyboard users can both discover and interact with the elements.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -442,8 +442,10 @@ export const Component = () => {
                         <col.icon className="w-3.5 h-3.5 flex-shrink-0" />
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
+                          aria-label={`Column options for ${col.label}`}
+                          title={`Column options for ${col.label}`}
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-0.5 rounded transition-all", t.iconBtn)}
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -492,8 +494,8 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day" aria-label={`Check all habits for ${row.day}`}
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -501,8 +503,10 @@ export const Component = () => {
                       <td className="px-4 py-3.5 text-center relative">
                         <div className="relative inline-block">
                           <button
+                            aria-label={`Row options for ${row.day}`}
+                            title={`Row options for ${row.day}`}
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>


### PR DESCRIPTION
💡 **What**: Added `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none` to elements that were previously only visible on hover (`opacity-0 group-hover:opacity-100`). Also added missing `aria-label` and `title` to these icon-only buttons.
🎯 **Why**: Relying solely on hover states for element visibility creates an accessibility trap for keyboard users (who navigate via Tab). This change ensures these elements are discoverable and interactive without a mouse.
♿ **Accessibility**: 
- Keyboard accessibility implemented via focus states.
- Screen reader and tooltip support improved by adding explicit `aria-label` and `title` properties.

---
*PR created automatically by Jules for task [12138523059988067109](https://jules.google.com/task/12138523059988067109) started by @aryankumar06*