### PR TITLE
🎨 Palette: Make resume upload keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-06-20 - Accessible file upload label
+**Learning:** Hiding the native `<input type="file">` visually (`display: none`) makes it inaccessible via keyboard navigation. The wrapper label needs to be focusable with `tabIndex={0}`, handle Enter/Space keys to trigger the upload, and show visible focus indicators.
+**Action:** Always verify that hidden inputs triggered by wrappers have proper keyboard focus and interaction support on the wrapper element.

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -319,15 +319,36 @@ export const Component = () => {
             ↓ Upload your resume by clicking the block below and choosing a file from your computer
           </p>
           <label
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                const fileInput = document.getElementById("resume-upload") as HTMLInputElement;
+                if (fileInput) fileInput.click();
+              }
+            }}
             style={{
               display: "flex", alignItems: "center", gap: 12,
               background: t.surfaceAlt, border: `1px solid ${t.border}`,
               borderRadius: 8, padding: "16px 20px",
               fontSize: 14, color: t.muted, cursor: "pointer",
-              transition: "border-color 0.2s",
+              transition: "all 0.2s",
+              outline: "none",
             }}
             onMouseEnter={(e) => (e.currentTarget.style.borderColor = "#3b82f6")}
-            onMouseLeave={(e) => (e.currentTarget.style.borderColor = t.border)}
+            onMouseLeave={(e) => {
+              if (document.activeElement !== e.currentTarget) {
+                e.currentTarget.style.borderColor = t.border;
+              }
+            }}
+            onFocus={(e) => {
+              e.currentTarget.style.borderColor = "#3b82f6";
+              e.currentTarget.style.boxShadow = "0 0 0 2px rgba(59, 130, 246, 0.2)";
+            }}
+            onBlur={(e) => {
+              e.currentTarget.style.borderColor = t.border;
+              e.currentTarget.style.boxShadow = "none";
+            }}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
@@ -339,6 +360,8 @@ export const Component = () => {
               ? <span style={{ color: t.text, display: "flex", alignItems: "center", gap: 8 }}>
                   <span>📄</span> {resumeFile}
                   <button
+                    aria-label="Remove resume"
+                    title="Remove resume"
                     onClick={(e) => { e.preventDefault(); setResumeFile(null); }}
                     style={{ background: "none", border: "none", cursor: "pointer", color: t.muted, padding: 2 }}
                   >
@@ -348,6 +371,7 @@ export const Component = () => {
               : "Upload or embed a file"
             }
             <input
+              id="resume-upload"
               type="file"
               style={{ display: "none" }}
               accept=".pdf,.doc,.docx"


### PR DESCRIPTION
💡 What: The UX enhancement added:
Made the resume upload area fully keyboard accessible and added a helpful ARIA label to the remove resume icon button.

🎯 Why: The user problem it solves:
The `<input type="file">` was visually hidden (`display: none`), meaning keyboard-only users could not tab to it, see focus, or trigger the file dialog.

📸 Before/After: Screenshots if visual change
The resume upload box now features a blue focus ring and box-shadow when navigating via keyboard (Tab).

♿ Accessibility: Any a11y improvements made:
- Wrapper `<label>` now accepts focus (`tabIndex={0}`).
- Keyboard interaction triggers upload (`Enter` or `Space`).
- Visual indication of focus implemented (`onFocus` / `onBlur`).
- Added missing `aria-label` and `title` to the remove resume button.

---
*PR created automatically by Jules for task [8794473038229835793](https://jules.google.com/task/8794473038229835793) started by @aryankumar06*