### PR TITLE
🎨 Palette: Fix keyboard accessibility focus traps on hidden row/column menus

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-05-24 - Keyboard Accessibility Traps with opacity-0 Hover States
+**Learning:** Elements hidden with `opacity-0 group-hover:opacity-100` create keyboard accessibility traps because they are not visually focusable by keyboard users using standard tabbing. Even if they are technically in the DOM, visual users navigating via keyboard cannot see them to interact with them.
+**Action:** When hiding elements using hover state opacity (e.g., `opacity-0 group-hover:opacity-100`), always include `focus-visible:opacity-100` and focus rings (e.g., `focus-visible:ring-2 focus-visible:outline-none`) to ensure the elements become visible and clearly focused when receiving keyboard focus.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -443,7 +443,9 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          aria-label={`Column menu for ${col.label}`}
+                          title={`Column menu for ${col.label}`}
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-0.5 rounded transition-all", t.iconBtn)}
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -492,8 +494,8 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                        <button onClick={() => handleCheckAllForDay(row.day)} aria-label={`Check all for ${row.day}`} title="Check all for this day"
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -502,7 +504,9 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            aria-label={`Row menu for ${row.day}`}
+                            title={`Row menu for ${row.day}`}
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>


### PR DESCRIPTION
🎨 Palette: Fix keyboard accessibility focus traps on hidden row/column menus

💡 What: Added `focus-visible:opacity-100`, focus rings, and explicit `aria-label`/`title` attributes to three icon buttons in the table that were previously hidden by `opacity-0` and only visible on hover.
🎯 Why: Keyboard users tabbing through the table could not see the column dropdown menu, row dropdown menu, or check-all buttons because they remained visually hidden (opacity 0) when focused. Now they properly appear and show focus state when tabbed to.
♿ Accessibility: Solved a critical keyboard accessibility trap and improved screen reader context by adding specific ARIA labels describing the actions.

---
*PR created automatically by Jules for task [2385983007757056496](https://jules.google.com/task/2385983007757056496) started by @aryankumar06*