### PR TITLE
🎨 Palette: Add keyboard accessibility to file upload label

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2026-06-22 - File Upload Label Keyboard Accessibility
+**Learning:** Hidden file inputs (`display: none`) make the wrapping `<label>` inaccessible to keyboard users, preventing them from triggering the upload dialog.
+**Action:** Always add `tabIndex={0}`, an `onKeyDown` handler (for Enter/Space), and visible focus styling (`onFocus`/`onBlur`) to the wrapping `<label>` when hiding the input.

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -319,6 +319,15 @@ export const Component = () => {
             ↓ Upload your resume by clicking the block below and choosing a file from your computer
           </p>
           <label
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.currentTarget.click();
+              }
+            }}
+            onFocus={(e) => (e.currentTarget.style.outline = "2px solid #3b82f6")}
+            onBlur={(e) => (e.currentTarget.style.outline = "none")}
             style={{
               display: "flex", alignItems: "center", gap: 12,
               background: t.surfaceAlt, border: `1px solid ${t.border}`,


### PR DESCRIPTION
💡 **What:** Added keyboard accessibility and focus styling to the file upload label in `job_tracker_component.tsx`.
🎯 **Why:** Hidden file inputs (`display: none`) are inaccessible to screen readers and keyboard-only users. By adding `tabIndex={0}`, an `onKeyDown` handler to listen for Space and Enter keys, and visual focus styling (`onFocus` and `onBlur`), keyboard users can now successfully trigger the file upload dialog.
♿ **Accessibility:** Added keyboard accessibility for file upload functionality.

---
*PR created automatically by Jules for task [6233309066167092150](https://jules.google.com/task/6233309066167092150) started by @aryankumar06*