### PR TITLE
🎨 Palette: Fix keyboard accessibility traps on hover-revealed buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-05-24 - Keyboard Accessibility for Hover-Revealed Elements
+**Learning:** Hiding UI elements like buttons purely with hover state (`opacity-0 group-hover:opacity-100`) creates a keyboard accessibility trap. Screen readers and keyboard navigators cannot trigger the hover state, effectively hiding these elements from them visually and making navigation confusing.
+**Action:** Always pair hover visibility toggles with explicit `focus-visible` styles and focus rings (e.g., `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none`) to ensure keyboard users can discover and interact with the elements.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -443,7 +443,9 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-0.5 rounded transition-all", t.iconBtn)}
+                          aria-label={`Options for ${col.label}`}
+                          title={`Options for ${col.label}`}
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -492,8 +494,8 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                        <button onClick={() => handleCheckAllForDay(row.day)} title={`Check all for ${row.day}`} aria-label={`Check all for ${row.day}`}
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -502,7 +504,9 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            aria-label={`Row options for ${row.day}`}
+                            title={`Row options for ${row.day}`}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>


### PR DESCRIPTION
🎨 Palette: Fix keyboard accessibility traps on hover-revealed buttons

* 💡 What: Added `focus-visible` styles (`focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none`) and explicit `aria-label`/`title` attributes to three sets of icon-only buttons that were previously hidden behind a hover state (`opacity-0 group-hover:opacity-100`). Documented the learning in `.Jules/palette.md`.
* 🎯 Why: Elements hidden purely with hover states become inaccessible keyboard traps because screen readers and keyboard users cannot trigger the hover state. The focus rings and visibility ensure they are discoverable and actionable via keyboard.
* 📸 Before/After: Visual changes apply only when interacting via keyboard.
* ♿ Accessibility: Fixes WCAG non-compliance for focus visibility and semantic labeling on hover-revealed interactive elements.

---
*PR created automatically by Jules for task [1388110596503111237](https://jules.google.com/task/1388110596503111237) started by @aryankumar06*