### PR TITLE
🎨 Palette: Make resume upload keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-06-25 - Hidden File Inputs Keyboard Accessibility
+**Learning:** Hiding file inputs (`display: none`) and replacing them visually with a wrapping `<label>` creates a keyboard accessibility trap. Screen readers might miss it, and keyboard users cannot focus or interact with it since the native `input` is completely hidden and labels aren't natively focusable.
+**Action:** When hiding file inputs, explicitly make the visible `<label>` wrapper focusable (`tabIndex={0}`) and add keyboard event handlers (like `onKeyDown` for "Enter" and "Space") to trigger the click on the underlying hidden input. Also provide visible focus states.

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -319,15 +319,35 @@ export const Component = () => {
             ↓ Upload your resume by clicking the block below and choosing a file from your computer
           </p>
           <label
+            tabIndex={0}
             style={{
               display: "flex", alignItems: "center", gap: 12,
               background: t.surfaceAlt, border: `1px solid ${t.border}`,
               borderRadius: 8, padding: "16px 20px",
               fontSize: 14, color: t.muted, cursor: "pointer",
-              transition: "border-color 0.2s",
+              transition: "border-color 0.2s, outline 0.2s",
             }}
             onMouseEnter={(e) => (e.currentTarget.style.borderColor = "#3b82f6")}
-            onMouseLeave={(e) => (e.currentTarget.style.borderColor = t.border)}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.borderColor = t.border;
+              e.currentTarget.style.outline = "none";
+            }}
+            onFocus={(e) => {
+              e.currentTarget.style.borderColor = "#3b82f6";
+              e.currentTarget.style.outline = "2px solid #3b82f6";
+              e.currentTarget.style.outlineOffset = "2px";
+            }}
+            onBlur={(e) => {
+              e.currentTarget.style.borderColor = t.border;
+              e.currentTarget.style.outline = "none";
+            }}
+            onKeyDown={(e) => {
+              if (e.target !== e.currentTarget) return;
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.currentTarget.querySelector("input")?.click();
+              }
+            }}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
@@ -339,7 +359,16 @@ export const Component = () => {
               ? <span style={{ color: t.text, display: "flex", alignItems: "center", gap: 8 }}>
                   <span>📄</span> {resumeFile}
                   <button
+                    aria-label="Remove file"
+                    title="Remove file"
                     onClick={(e) => { e.preventDefault(); setResumeFile(null); }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setResumeFile(null);
+                        e.stopPropagation();
+                      }
+                    }}
                     style={{ background: "none", border: "none", cursor: "pointer", color: t.muted, padding: 2 }}
                   >
                     <XIcon size={12} />


### PR DESCRIPTION
💡 **What:** Added keyboard support and focus visibility to the hidden resume file input's wrapper label, and added an accessible name to the "Remove file" icon button.
🎯 **Why:** Hiding an `input type="file"` (`display: none`) and replacing it visually with a `<label>` creates an accessibility trap for keyboard and screen-reader users, as the native input cannot be focused or activated. Icon-only buttons also require ARIA labels.
📸 **Before/After:** The resume block now receives a visible blue focus ring when navigating via keyboard, and pressing Enter or Space opens the file picker correctly.
♿ **Accessibility:** Fixes a keyboard trap and ensures proper ARIA labeling for the clear button.

---
*PR created automatically by Jules for task [2482403225141751402](https://jules.google.com/task/2482403225141751402) started by @aryankumar06*