### PR TITLE
🎨 Palette: Make hidden resume file upload fully keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-06-30 - Keyboard Accessibility for Hidden File Inputs
+**Learning:** When using `<label>` wrappers with hidden file inputs (`display: none`) to create custom upload areas, the control loses keyboard accessibility because standard hidden inputs cannot receive focus.
+**Action:** Always add `tabIndex={0}`, keyboard event handlers (`onKeyDown` for Enter/Space), and explicit focus state styling (`onFocus`/`onBlur`) to the wrapping `<label>` element to restore full keyboard interactivity.

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -319,6 +319,7 @@ export const Component = () => {
             ↓ Upload your resume by clicking the block below and choosing a file from your computer
           </p>
           <label
+            tabIndex={0}
             style={{
               display: "flex", alignItems: "center", gap: 12,
               background: t.surfaceAlt, border: `1px solid ${t.border}`,
@@ -328,6 +329,15 @@ export const Component = () => {
             }}
             onMouseEnter={(e) => (e.currentTarget.style.borderColor = "#3b82f6")}
             onMouseLeave={(e) => (e.currentTarget.style.borderColor = t.border)}
+            onFocus={(e) => (e.currentTarget.style.borderColor = "#3b82f6")}
+            onBlur={(e) => (e.currentTarget.style.borderColor = t.border)}
+            onKeyDown={(e) => {
+              if (e.target !== e.currentTarget) return;
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.currentTarget.click();
+              }
+            }}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
@@ -341,6 +351,8 @@ export const Component = () => {
                   <button
                     onClick={(e) => { e.preventDefault(); setResumeFile(null); }}
                     style={{ background: "none", border: "none", cursor: "pointer", color: t.muted, padding: 2 }}
+                    aria-label="Remove resume file"
+                    title="Remove resume file"
                   >
                     <XIcon size={12} />
                   </button>


### PR DESCRIPTION
### 💡 What
Added `tabIndex={0}`, matching `onFocus` and `onBlur` visual styling, and an `onKeyDown` handler to the hidden file input's wrapper `<label>` in `job_tracker_component.tsx`. Also added `aria-label` and `title` attributes to the icon-only "remove resume" button.

### 🎯 Why
When using custom styled `<label>` elements to wrap hidden file `<input>` elements (`display: none`), the component loses keyboard accessibility since hidden inputs cannot receive focus. Keyboard users and screen readers had no way to focus or activate the resume upload block. Adding these attributes and handlers restores parity with native file inputs for keyboard users. Adding aria-labels to the icon-only remove button gives screen readers context on what the button actually does.

### ♿ Accessibility
- Hidden file upload control is now fully keyboard focusable and interactive via `Enter`/`Space`.
- Removes inaccessible "Remove file" icon-only button trap by adding descriptive text to screen readers.

---
*PR created automatically by Jules for task [3635164916329559640](https://jules.google.com/task/3635164916329559640) started by @aryankumar06*