### PR TITLE
🎨 Palette: Improve keyboard accessibility for file upload and icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2025-02-18 - Keyboard Accessibility for Hidden File Inputs
+**Learning:** When using a `<label>` to visually wrap and trigger a hidden `<input type="file">`, the label itself is not inherently focusable or keyboard actionable. This prevents screen reader and keyboard-only users from accessing the file upload functionality.
+**Action:** Always add `tabIndex={0}`, keyboard event handlers (`onKeyDown` for Enter/Space), and visual focus indicators (`onFocus`/`onBlur` or CSS `:focus-visible`) to the wrapping `<label>` to ensure keyboard accessibility.

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -319,15 +319,27 @@ export const Component = () => {
             ↓ Upload your resume by clicking the block below and choosing a file from your computer
           </p>
           <label
+            tabIndex={0}
             style={{
               display: "flex", alignItems: "center", gap: 12,
               background: t.surfaceAlt, border: `1px solid ${t.border}`,
               borderRadius: 8, padding: "16px 20px",
               fontSize: 14, color: t.muted, cursor: "pointer",
               transition: "border-color 0.2s",
+              outline: "none",
             }}
             onMouseEnter={(e) => (e.currentTarget.style.borderColor = "#3b82f6")}
             onMouseLeave={(e) => (e.currentTarget.style.borderColor = t.border)}
+            onFocus={(e) => (e.currentTarget.style.borderColor = "#3b82f6")}
+            onBlur={(e) => (e.currentTarget.style.borderColor = t.border)}
+            onKeyDown={(e) => {
+              if (e.target !== e.currentTarget) return;
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                const input = e.currentTarget.querySelector('input[type="file"]');
+                if (input) (input as HTMLInputElement).click();
+              }
+            }}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
@@ -341,6 +353,8 @@ export const Component = () => {
                   <button
                     onClick={(e) => { e.preventDefault(); setResumeFile(null); }}
                     style={{ background: "none", border: "none", cursor: "pointer", color: t.muted, padding: 2 }}
+                    aria-label="Remove resume"
+                    title="Remove resume"
                   >
                     <XIcon size={12} />
                   </button>


### PR DESCRIPTION
💡 What: Added keyboard support (`tabIndex`, `onKeyDown`, `onFocus`, `onBlur`) to the visually hidden file upload `<label>` and added `aria-label`/`title` to the remove resume icon button.
🎯 Why: Hidden file inputs wrapped in labels are inaccessible to keyboard and screen reader users by default. Icon-only buttons need descriptive labels for screen readers and visual tooltips for sighted users.
📸 Before/After: Visual focus state is now visible via blue border when navigating via keyboard.
♿ Accessibility: Ensures full keyboard navigability for the resume upload feature and proper screen reader announcements for the remove button.

---
*PR created automatically by Jules for task [262580109816718827](https://jules.google.com/task/262580109816718827) started by @aryankumar06*