### PR TITLE
🎨 Palette: Fix keyboard accessibility on hover-hidden buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+## 2024-07-06 - Keyboard Accessible Hover-Hidden Elements
+**Learning:** Hiding elements via `opacity-0 group-hover:opacity-100` creates accessibility traps for keyboard users because elements remain invisible on focus.
+**Action:** Always include `focus-visible:opacity-100` and a focus ring (`focus-visible:ring-2 focus-visible:outline-none`) alongside hover states to ensure keyboard accessibility.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -443,7 +443,8 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          aria-label="Column menu" title="Column menu"
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-0.5 rounded transition-all", t.iconBtn)}
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -492,8 +493,8 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                        <button onClick={() => handleCheckAllForDay(row.day)} aria-label="Check all for this day" title="Check all for this day"
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -502,7 +503,8 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            aria-label="Row menu" title="Row menu"
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>


### PR DESCRIPTION
💡 **What:** Added focus-visible styles and ARIA labels to hover-hidden icon buttons in `habit_tracker_component.tsx`.

🎯 **Why:** To improve keyboard accessibility. Hidden interactive elements (like the column menu, row menu, and check-all buttons) were previously only visible on mouse hover, creating a trap for keyboard-only users who couldn't see what they were focusing on.

♿ **Accessibility:**
- Added `focus-visible:opacity-100` and a visible focus ring (`focus-visible:ring-2 focus-visible:outline-none`) to ensure keyboard users see their focus location.
- Added `aria-label` and `title` attributes for improved screen reader support and mouse tooltips.

---
*PR created automatically by Jules for task [16108413172119233150](https://jules.google.com/task/16108413172119233150) started by @aryankumar06*