### PR TITLE
🎨 Palette: Improve keyboard accessibility for hover-hidden elements in Habit Tracker

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-10-24 - Focus Visibility on Hover-Hidden Elements
+**Learning:** Hiding UI elements using hover states (e.g., `opacity-0 group-hover:opacity-100`) creates keyboard accessibility traps, as users navigating via the keyboard cannot see the elements when they receive focus.
+**Action:** Always include `focus-visible:opacity-100` along with visual focus indicators like `focus-visible:ring-2 focus-visible:outline-none` when applying hover-based visibility patterns.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -443,7 +443,8 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-0.5 rounded transition-all", t.iconBtn)}
+                          aria-label={`Column menu for ${col.label}`} title={`Column menu for ${col.label}`}
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -493,7 +494,8 @@ export const Component = () => {
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
                         <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                          aria-label={`Check all for ${row.day}`}
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -502,7 +504,8 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            aria-label={`Row menu for ${row.day}`} title={`Row menu for ${row.day}`}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>


### PR DESCRIPTION
🎨 Palette: Fix focus visibility on hover-hidden elements

💡 **What**: Added `focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none` classes and explicit `aria-label`/`title` attributes to the Column Menu, Check-all, and Row Menu buttons in `habit_tracker_component.tsx`. Also added a critical UX learning to `.Jules/palette.md`.

🎯 **Why**: These icon-only buttons were hidden by default using `opacity-0` and only became visible on hover (`group-hover:opacity-100`). This created an accessibility trap for keyboard users, who would tab to the elements but remain unable to see them or understand their purpose without screen readers.

♿ **Accessibility**: Ensures hidden interactive elements are visible upon keyboard focus and properly labeled for screen readers and sighted users needing tooltips.

---
*PR created automatically by Jules for task [12845664704325503171](https://jules.google.com/task/12845664704325503171) started by @aryankumar06*