### PR TITLE
🎨 Palette: Fix keyboard focus traps on hover-hidden buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-06-03 - Keyboard Focus Traps on Hover-Hidden UI Elements
+**Learning:** Hiding UI elements using hover states (e.g., `opacity-0 group-hover:opacity-100`) creates a keyboard accessibility trap. Screen reader and keyboard-only users will focus these elements, but without explicit focus styles, they remain invisible, leaving users disoriented about their current location on the page.
+**Action:** When using hover-hidden elements, always include `focus-visible:opacity-100` and focus rings (e.g., `focus-visible:ring-2 focus-visible:outline-none`) to ensure the elements become visible and clearly highlighted when receiving keyboard focus.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -443,7 +443,9 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          aria-label="Column settings"
+                          title="Column settings"
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-0.5 rounded transition-all", t.iconBtn)}
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -492,8 +494,8 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                        <button onClick={() => handleCheckAllForDay(row.day)} aria-label={`Check all for ${row.day}`} title="Check all for this day"
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -502,7 +504,9 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            aria-label={`Row actions for ${row.day}`}
+                            title="Row actions"
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>


### PR DESCRIPTION
💡 What: Added `focus-visible` styles (`focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none`) and missing `aria-label`/`title` attributes to hover-hidden UI elements in the habit tracker component.
🎯 Why: Elements hidden with `opacity-0 group-hover:opacity-100` create a trap for keyboard users—they receive focus but remain invisible, causing disorientation.
♿ Accessibility: Ensures interactive elements remain visible and clearly highlighted when focused via keyboard (Tab), improving usability for screen reader and keyboard-only users. Documented learning in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [13727278297772583606](https://jules.google.com/task/13727278297772583606) started by @aryankumar06*