### PR TITLE
🎨 Palette: Improve keyboard accessibility for file upload

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2026-07-13 - Hidden File Input Accessibility
+**Learning:** Hidden file inputs (`display: none`) wrapped in custom `<label>` elements are inaccessible to keyboard users because standard `<input type="file">` interactions are lost when hidden.
+**Action:** When wrapping hidden file inputs in a `<label>`, always add `tabIndex={0}`, an `onKeyDown` handler to trigger the upload via `Enter`/`Space` (with `e.target !== e.currentTarget` return to handle event bubbling), and explicit `onFocus` and `onBlur` visual styling to restore keyboard accessibility.

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -319,6 +319,7 @@ export const Component = () => {
             ↓ Upload your resume by clicking the block below and choosing a file from your computer
           </p>
           <label
+            tabIndex={0}
             style={{
               display: "flex", alignItems: "center", gap: 12,
               background: t.surfaceAlt, border: `1px solid ${t.border}`,
@@ -328,6 +329,15 @@ export const Component = () => {
             }}
             onMouseEnter={(e) => (e.currentTarget.style.borderColor = "#3b82f6")}
             onMouseLeave={(e) => (e.currentTarget.style.borderColor = t.border)}
+            onFocus={(e) => (e.currentTarget.style.borderColor = "#3b82f6")}
+            onBlur={(e) => (e.currentTarget.style.borderColor = t.border)}
+            onKeyDown={(e) => {
+              if (e.target !== e.currentTarget) return;
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.currentTarget.querySelector("input")?.click();
+              }
+            }}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
@@ -341,6 +351,8 @@ export const Component = () => {
                   <button
                     onClick={(e) => { e.preventDefault(); setResumeFile(null); }}
                     style={{ background: "none", border: "none", cursor: "pointer", color: t.muted, padding: 2 }}
+                    aria-label="Remove resume"
+                    title="Remove resume"
                   >
                     <XIcon size={12} />
                   </button>


### PR DESCRIPTION
💡 **What**: Added comprehensive keyboard accessibility to the "Upload resume" section in `job_tracker_component.tsx`. The wrapping `<label>` can now be tabbed to, receives visual focus styling (blue border), and supports triggering the hidden file input via `Enter` or `Space`. Also added `aria-label` and `title` to the icon-only "Remove resume" button.

🎯 **Why**: Previously, the file upload input was hidden via `display: none` and wrapped in a `<label>`. This completely removed it from the tab order, meaning keyboard-only users could not upload a resume. Additionally, the clear button lacked context for screen readers.

♿ **Accessibility**: 
- Added `tabIndex=0` and keyboard handlers to custom label button.
- Prevented event bubbling issues with `e.target !== e.currentTarget` checks.
- Added focus/blur styling to indicate focus state.
- Added ARIA label to remove button.

---
*PR created automatically by Jules for task [9244796217826705263](https://jules.google.com/task/9244796217826705263) started by @aryankumar06*