### PR TITLE
🎨 Palette: Accessible Resume File Upload

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-07-15 - Accessibility for Hidden File Inputs
+**Learning:** Hiding file inputs (e.g., `display: none`) and replacing them with styled wrappers like a `<label>` breaks keyboard accessibility by default, because hidden inputs cannot receive focus.
+**Action:** When a styled `<label>` acts as a file upload button, make the wrapper keyboard accessible by adding `tabIndex={0}`, an `onKeyDown` handler that triggers the nested input on 'Enter' or 'Space' while preventing bubbling (`if (e.target !== e.currentTarget) return;`), and `onFocus`/`onBlur` styles to provide a visible focus indicator for keyboard users.

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -319,6 +319,16 @@ export const Component = () => {
             ↓ Upload your resume by clicking the block below and choosing a file from your computer
           </p>
           <label
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.target !== e.currentTarget) return;
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.currentTarget.querySelector("input")?.click();
+              }
+            }}
+            onFocus={(e) => (e.currentTarget.style.borderColor = "#3b82f6")}
+            onBlur={(e) => (e.currentTarget.style.borderColor = t.border)}
             style={{
               display: "flex", alignItems: "center", gap: 12,
               background: t.surfaceAlt, border: `1px solid ${t.border}`,
@@ -339,6 +349,8 @@ export const Component = () => {
               ? <span style={{ color: t.text, display: "flex", alignItems: "center", gap: 8 }}>
                   <span>📄</span> {resumeFile}
                   <button
+                    aria-label="Remove resume"
+                    title="Remove resume"
                     onClick={(e) => { e.preventDefault(); setResumeFile(null); }}
                     style={{ background: "none", border: "none", cursor: "pointer", color: t.muted, padding: 2 }}
                   >


### PR DESCRIPTION
💡 What: Added keyboard accessibility to the hidden resume file input wrapper and accessible labels to the remove button.
🎯 Why: Hidden file inputs wrapped in labels break native focus. Without these changes, keyboard-only or screen reader users cannot focus, activate, or clear the resume upload field.
♿ Accessibility:
- Added `tabIndex={0}` and keyboard event handling to the upload label.
- Added visible focus rings on the upload label.
- Added `aria-label` and `title` to the icon-only remove file button.

---
*PR created automatically by Jules for task [15248442771596853938](https://jules.google.com/task/15248442771596853938) started by @aryankumar06*