### PR TITLE
🎨 Palette: Improve File Upload Keyboard Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-07-17 - Keyboard Accessibility for Hidden File Inputs
+**Learning:** When hiding `<input type="file">` elements using `display: none` for custom styling via a wrapper `<label>`, the entire upload functionality becomes inaccessible to keyboard users because the hidden input is removed from the focus order. Standard browser handling via Space/Enter keys on the `<label>` only works if it receives focus.
+**Action:** Always add `tabIndex={0}` to the wrapper `<label>` containing a hidden file input, and implement an `onKeyDown` handler to trigger `e.currentTarget.click()` upon Enter/Space keystrokes. It's also crucial to add `if (e.target !== e.currentTarget) return;` to prevent nested buttons (like "remove file" icons) from inadvertently triggering the file dialog via event bubbling.

--- a/job_tracker_component.tsx
+++ b/job_tracker_component.tsx
@@ -319,15 +319,25 @@ export const Component = () => {
             ↓ Upload your resume by clicking the block below and choosing a file from your computer
           </p>
           <label
+            tabIndex={0}
             style={{
               display: "flex", alignItems: "center", gap: 12,
               background: t.surfaceAlt, border: `1px solid ${t.border}`,
               borderRadius: 8, padding: "16px 20px",
               fontSize: 14, color: t.muted, cursor: "pointer",
-              transition: "border-color 0.2s",
+              transition: "border-color 0.2s, box-shadow 0.2s",
             }}
             onMouseEnter={(e) => (e.currentTarget.style.borderColor = "#3b82f6")}
             onMouseLeave={(e) => (e.currentTarget.style.borderColor = t.border)}
+            onFocus={(e) => { e.currentTarget.style.borderColor = "#3b82f6"; e.currentTarget.style.boxShadow = "0 0 0 2px rgba(59, 130, 246, 0.5)"; }}
+            onBlur={(e) => { e.currentTarget.style.borderColor = t.border; e.currentTarget.style.boxShadow = "none"; }}
+            onKeyDown={(e) => {
+              if (e.target !== e.currentTarget) return;
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.currentTarget.click();
+              }
+            }}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
@@ -339,6 +349,8 @@ export const Component = () => {
               ? <span style={{ color: t.text, display: "flex", alignItems: "center", gap: 8 }}>
                   <span>📄</span> {resumeFile}
                   <button
+                    aria-label="Remove uploaded resume"
+                    title="Remove uploaded resume"
                     onClick={(e) => { e.preventDefault(); setResumeFile(null); }}
                     style={{ background: "none", border: "none", cursor: "pointer", color: t.muted, padding: 2 }}
                   >


### PR DESCRIPTION
💡 What: Added keyboard accessibility to the file upload block (tabIndex, keyboard event handler for Space/Enter, focus-visible styles) and added ARIA label and tooltip to the icon-only "remove resume" button.
🎯 Why: Hidden `<input type="file">` elements within `<label>` wrappers lose keyboard accessibility. This change ensures users relying on keyboards or assistive tech can successfully upload or remove files.
📸 Before/After: Visual focus state is now visible via a blue ring outline when focused.
♿ Accessibility: Ensures interactive components are keyboard-operable, properly labeled for screen readers, and protected against event bubbling side-effects.

---
*PR created automatically by Jules for task [6027451772175796823](https://jules.google.com/task/6027451772175796823) started by @aryankumar06*