### PR TITLE
🎨 Palette: Add focus-visible states to hover-hidden action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Accessibility and Tooltips on Icon-Only Buttons
 **Learning:** Icon-only buttons must explicitly declare both `aria-label` (for screen readers) and `title` (for visual tooltips). In Shadcn/Lucide setups, icons don't inherently communicate their action to either assistive technologies or sighted users needing clarification. Missing these attributes is a common accessibility trap in dense UIs like habit trackers.
 **Action:** Always add both `aria-label` and `title` attributes to icon-only buttons as a standard procedure to ensure an inclusive and intuitive user experience.
+
+## 2024-05-24 - Keyboard Accessibility for Hover-Hidden Elements
+**Learning:** Hiding UI elements like action buttons behind hover states (e.g., `opacity-0 group-hover:opacity-100`) creates a trap for keyboard users because tabbing into them doesn't reveal them visually, leaving users confused about focus state.
+**Action:** Always pair `opacity-0` hover hiding with `focus-visible:opacity-100` and clear focus rings (e.g., `focus-visible:ring-2 focus-visible:outline-none`) to guarantee that these elements become visible and clearly styled when they receive keyboard focus.

--- a/habit_tracker_component.tsx
+++ b/habit_tracker_component.tsx
@@ -443,7 +443,9 @@ export const Component = () => {
                         <span className="whitespace-nowrap">{col.label}</span>
                         <button
                           onClick={(e) => { e.stopPropagation(); setColMenuKey(colMenuKey === col.key ? null : col.key); }}
-                          className={cn("ml-1 opacity-0 group-hover:opacity-100 p-0.5 rounded transition-all", t.iconBtn)}
+                          title="Column actions"
+                          aria-label="Column actions"
+                          className={cn("ml-1 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-0.5 rounded transition-all", t.iconBtn)}
                         >
                           <ChevronDown className="w-3 h-3" />
                         </button>
@@ -492,8 +494,8 @@ export const Component = () => {
                       ))}
                       {/* Check-all cell */}
                       <td className={cn("px-4 py-3.5 border-r text-center", t.cellBorder)}>
-                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day"
-                          className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}>
+                        <button onClick={() => handleCheckAllForDay(row.day)} title="Check all for this day" aria-label={`Check all habits for ${row.day}`}
+                          className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}>
                           <Check className="w-3.5 h-3.5" />
                         </button>
                       </td>
@@ -502,7 +504,9 @@ export const Component = () => {
                         <div className="relative inline-block">
                           <button
                             onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                            className={cn("opacity-0 group-hover:opacity-100 p-1 rounded transition-all", t.iconBtn, t.muted)}
+                            title="Row actions"
+                            aria-label={`Row actions for ${row.day}`}
+                            className={cn("opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none p-1 rounded transition-all", t.iconBtn, t.muted)}
                           >
                             <MoreHorizontal className="w-3.5 h-3.5" />
                           </button>
@@ -584,7 +588,9 @@ export const Component = () => {
                   <div className="w-8 flex justify-center relative">
                     <button
                       onClick={(e) => { e.stopPropagation(); setRowMenu(rowMenu?.day === row.day ? null : { day: row.day }); }}
-                      className={cn("p-1 rounded transition-colors", t.iconBtn, t.muted)}
+                      title="Row actions"
+                      aria-label={`Row actions for ${row.day}`}
+                      className={cn("p-1 rounded transition-colors focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none", t.iconBtn, t.muted)}
                     >
                       <MoreHorizontal className="w-4 h-4" />
                     </button>


### PR DESCRIPTION
💡 **What**: Added visible focus states (`focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none`) and proper ARIA labels/titles to the action buttons in the habit tracker grid that are normally hidden behind a hover state. Added learning to `.Jules/palette.md`.

🎯 **Why**: When action buttons (like row options or "check all") are hidden via `opacity-0` and only revealed on hover, keyboard-only users who navigate via `Tab` cannot see which element has focus. This change ensures these buttons become fully visible and styled with a focus ring when navigated to via keyboard, preventing an accessibility trap.

📸 **Before/After**: Keyboard users tabbing through the grid can now clearly see when their focus lands on the action buttons (column dropdowns, check-all cells, and row menu dropdowns).

♿ **Accessibility**: 
- Fixed keyboard focus visibility for hidden interactive elements.
- Ensured all updated icon-only buttons provide accessible names via `aria-label` and visual tooltips via `title`.

---
*PR created automatically by Jules for task [234913523164631900](https://jules.google.com/task/234913523164631900) started by @aryankumar06*